### PR TITLE
consistent naming

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
+++ b/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
@@ -120,7 +120,7 @@ public class BeaconSender implements Runnable {
 	private void handleStatusResponse(StatusResponse statusResponse) {
 		configuration.updateSettings(statusResponse);
 
-		// if capture is off -> clear Sessions on beacon sender and leave other settings on their current values
+		// if capture is off -> clear Sessions
 		if (!configuration.isCapture()) {
 			clearSessions();
 		}

--- a/src/main/java/com/dynatrace/openkit/core/configuration/AbstractConfiguration.java
+++ b/src/main/java/com/dynatrace/openkit/core/configuration/AbstractConfiguration.java
@@ -8,12 +8,8 @@ package com.dynatrace.openkit.core.configuration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.dynatrace.openkit.core.BeaconSender;
 import com.dynatrace.openkit.core.DeviceImpl;
-import com.dynatrace.openkit.core.SessionImpl;
-import com.dynatrace.openkit.protocol.HTTPClient;
 import com.dynatrace.openkit.protocol.StatusResponse;
-import com.dynatrace.openkit.providers.HTTPClientProvider;
 
 /**
  * The AbstractConfiguration class holds all configuration settings, both provided by the user and the Dynatrace/AppMon server.
@@ -41,7 +37,7 @@ public abstract class AbstractConfiguration {
 	private int maxBeaconSize;									// max beacon size; is only written/read by beacon sender thread -> non-atomic
 	private AtomicBoolean captureErrors;						// capture errors on/off; can be written/read by different threads -> atomic
 	private AtomicBoolean captureCrashes;						// capture crashes on/off; can be written/read by different threads -> atomic
-	private HttpClientConfiguration httpClientConfiguration; 	// the current http client configuration
+	private HTTPClientConfiguration httpClientConfiguration; 	// the current http client configuration
 
 	// application and device settings
 	private String applicationVersion;
@@ -73,7 +69,7 @@ public abstract class AbstractConfiguration {
 		device = new DeviceImpl();
 		applicationVersion = null;
 
-		httpClientConfiguration = new HttpClientConfiguration(
+		httpClientConfiguration = new HTTPClientConfiguration(
 				createBaseURL(endpointURL, monitorName),
 				openKitType.getDefaultServerID(),
 				applicationID,
@@ -96,7 +92,7 @@ public abstract class AbstractConfiguration {
 			capture.set(statusResponse.isCapture());
 		}
 
-		// if capture is off -> clear Sessions on beacon sender and leave other settings on their current values
+		// if capture is off -> leave other settings on their current values
 		if (!isCapture()) {
 			return;
 		}
@@ -115,13 +111,13 @@ public abstract class AbstractConfiguration {
 
 		boolean httpConfigChanged = false;
 		if (!monitorName.equals(newMonitorName)
-				|| httpClientConfiguration.getServerId() != newServerID) {
+				|| httpClientConfiguration.getServerID() != newServerID) {
 			httpConfigChanged = true;
 		}
 
 		// http config changed -> new config
 		if (httpConfigChanged) {
-			httpClientConfiguration = new HttpClientConfiguration(
+			httpClientConfiguration = new HTTPClientConfiguration(
 					createBaseURL(endpointURL, newMonitorName),
 					newServerID,
 					applicationID,
@@ -212,5 +208,5 @@ public abstract class AbstractConfiguration {
 	 *
 	 * @return
 	 */
-	public HttpClientConfiguration getHttpClientConfig() { return httpClientConfiguration; }
+	public HTTPClientConfiguration getHttpClientConfig() { return httpClientConfiguration; }
 }

--- a/src/main/java/com/dynatrace/openkit/core/configuration/HTTPClientConfiguration.java
+++ b/src/main/java/com/dynatrace/openkit/core/configuration/HTTPClientConfiguration.java
@@ -1,20 +1,20 @@
 package com.dynatrace.openkit.core.configuration;
 
 /**
- * The HttpClientConfiguration holds all http client related settings
+ * The HTTPClientConfiguration holds all http client related settings
  */
-public class HttpClientConfiguration {
+public class HTTPClientConfiguration {
 
 	// all fields are immutable
 	private final String baseUrl;
 	private final int serverId;
-	private final String applicationId;
+	private final String applicationID;
 	private final boolean verbose;
 
-	public HttpClientConfiguration(String baseUrl, int serverId, String applicationId, boolean verbose) {
+	public HTTPClientConfiguration(String baseUrl, int serverID, String applicationID, boolean verbose) {
 		this.baseUrl = baseUrl;
-		this.serverId = serverId;
-		this.applicationId = applicationId;
+		this.serverId = serverID;
+		this.applicationID = applicationID;
 		this.verbose = verbose;
 	}
 
@@ -30,14 +30,14 @@ public class HttpClientConfiguration {
 	 *
 	 * @return the server id
 	 */
-	public int getServerId() { return serverId; }
+	public int getServerID() { return serverId; }
 
 	/**
 	 * The application id for the http client
 	 *
 	 * @return the application id
 	 */
-	public String getApplicationId() { return applicationId; }
+	public String getApplicationID() { return applicationID; }
 
 	/**
 	 * If {@code true} logging is enabled

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -15,7 +15,7 @@ import com.dynatrace.openkit.core.ActionImpl;
 import com.dynatrace.openkit.core.configuration.AbstractConfiguration;
 import com.dynatrace.openkit.core.SessionImpl;
 import com.dynatrace.openkit.core.WebRequestTagBaseImpl;
-import com.dynatrace.openkit.core.configuration.HttpClientConfiguration;
+import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 import com.dynatrace.openkit.providers.HTTPClientProvider;
 import com.dynatrace.openkit.providers.ThreadIDProvider;
 import com.dynatrace.openkit.providers.TimeProvider;
@@ -95,8 +95,8 @@ public class Beacon {
 	// AbstractConfiguration reference
 	private final AbstractConfiguration configuration;
 
-	// HttpClientConfiguration reference
-	private final HttpClientConfiguration httpConfiguration;
+	// HTTPClientConfiguration reference
+	private final HTTPClientConfiguration httpConfiguration;
 
 	// lists of events and actions currently on the Beacon
 	private final LinkedList<String> eventDataList = new LinkedList<String>();
@@ -132,7 +132,7 @@ public class Beacon {
 	public String createTag(ActionImpl parentAction, int sequenceNo) {
 		return TAG_PREFIX + "_"
 				   + PROTOCOL_VERSION + "_"
-				   + httpConfiguration.getServerId() + "_"
+				   + httpConfiguration.getServerID() + "_"
 				   + configuration.getVisitorID() + "_"
 				   + sessionNumber + "_"
 				   + configuration.getApplicationID() + "_"

--- a/src/main/java/com/dynatrace/openkit/providers/DefaultHTTPClientProvider.java
+++ b/src/main/java/com/dynatrace/openkit/providers/DefaultHTTPClientProvider.java
@@ -5,7 +5,7 @@
  */
 package com.dynatrace.openkit.providers;
 
-import com.dynatrace.openkit.core.configuration.HttpClientConfiguration;
+import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 import com.dynatrace.openkit.protocol.HTTPClient;
 
 /**
@@ -14,8 +14,8 @@ import com.dynatrace.openkit.protocol.HTTPClient;
 public class DefaultHTTPClientProvider implements HTTPClientProvider {
 
 	@Override
-	public HTTPClient createClient(HttpClientConfiguration configuration) {
-		return new HTTPClient(configuration.getBaseUrl(), configuration.getApplicationId(), configuration.getServerId(), configuration.isVerbose());
+	public HTTPClient createClient(HTTPClientConfiguration configuration) {
+		return new HTTPClient(configuration.getBaseUrl(), configuration.getApplicationID(), configuration.getServerID(), configuration.isVerbose());
 	}
 
 }

--- a/src/main/java/com/dynatrace/openkit/providers/HTTPClientProvider.java
+++ b/src/main/java/com/dynatrace/openkit/providers/HTTPClientProvider.java
@@ -5,12 +5,12 @@
  */
 package com.dynatrace.openkit.providers;
 
-import com.dynatrace.openkit.core.configuration.HttpClientConfiguration;
+import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 import com.dynatrace.openkit.protocol.HTTPClient;
 
 /**
  * Abstract class for providing an HTTP client. Mostly needed for testing purposes.
  */
 public interface HTTPClientProvider {
-	HTTPClient createClient(HttpClientConfiguration configuration);
+	HTTPClient createClient(HTTPClientConfiguration configuration);
 }

--- a/src/test/java/com/dynatrace/openkit/providers/TestHTTPClientProvider.java
+++ b/src/test/java/com/dynatrace/openkit/providers/TestHTTPClientProvider.java
@@ -7,7 +7,7 @@ package com.dynatrace.openkit.providers;
 
 import java.util.ArrayList;
 
-import com.dynatrace.openkit.core.configuration.HttpClientConfiguration;
+import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 import com.dynatrace.openkit.protocol.HTTPClient;
 import com.dynatrace.openkit.test.TestHTTPClient;
 import com.dynatrace.openkit.test.TestHTTPClient.Request;
@@ -29,13 +29,13 @@ public class TestHTTPClientProvider implements HTTPClientProvider {
 	}
 
 	@Override
-	public HTTPClient createClient(HttpClientConfiguration configuration) {
+	public HTTPClient createClient(HTTPClientConfiguration configuration) {
 		if (testHTTPClient != null) {
 			previouslySentRequests.addAll(testHTTPClient.getSentRequests());
 		}
 
-		testHTTPClient = new TestHTTPClient(configuration.getBaseUrl(), configuration.getApplicationId(),
-				configuration.getServerId(), remoteTest, configuration.isVerbose());
+		testHTTPClient = new TestHTTPClient(configuration.getBaseUrl(), configuration.getApplicationID(),
+				configuration.getServerID(), remoteTest, configuration.isVerbose());
 		if (statusResponse != null) {
 			testHTTPClient.setStatusResponse(statusResponse, statusResponseCode);
 		}


### PR DESCRIPTION
- Renamed HttpClientConfiguration to HTTPClientConfiguration
- use "ID" instead of "Id" in client config