### PR TITLE
Fixes in Javadoc to get rid of Javadoc errors

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/WebRequestTracerStringURL.java
+++ b/src/main/java/com/dynatrace/openkit/core/WebRequestTracerStringURL.java
@@ -9,8 +9,8 @@ import com.dynatrace.openkit.api.OpenKit;
 import com.dynatrace.openkit.protocol.Beacon;
 
 /**
+ * Setting the Dynatrace tag to the {@link OpenKit#WEBREQUEST_TAG_HEADER} HTTP header has to be done manually by the user.
  * Inherited class of {@link WebRequestTracerBaseImpl} which can be used for tracing and timing of a web request handled by any 3rd party HTTP Client.
- * Setting the Dynatrace tag to the {@link OpenKit.WEBREQUEST_TAG_HEADER} HTTP header has to be done manually by the user.
  */
 public class WebRequestTracerStringURL extends WebRequestTracerBaseImpl {
 

--- a/src/main/java/com/dynatrace/openkit/protocol/StatusResponse.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/StatusResponse.java
@@ -8,7 +8,7 @@ package com.dynatrace.openkit.protocol;
 import java.util.StringTokenizer;
 
 /**
- * Implements a status response which is sent for the request types status check & beacon send.
+ * Implements a status response which is sent for the request types status check and beacon send.
  */
 public class StatusResponse extends Response {
 


### PR DESCRIPTION
Now gradlew javadoc also works without errors.
The warnings are ignored for now. :(