### PR TITLE
OpenKitConstants

### DIFF
--- a/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
+++ b/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
@@ -1,0 +1,14 @@
+package com.dynatrace.openkit.api;
+
+/**
+ * Defines constant values used in OpenKit
+ */
+public class OpenKitConstants {
+
+    // default values used in configuration
+    public static final String DEFAULT_APPLICATION_VERSION = "0.4";
+    public static final String DEFAULT_OPERATING_SYSTEM = "OpenKit " + DEFAULT_APPLICATION_VERSION;
+    public static final String DEFAULT_MANUFACTURER = "Dynatrace";
+    public static final String DEFAULT_DEVICE_ID = "OpenKitDevice";
+
+}

--- a/src/main/java/com/dynatrace/openkit/core/DeviceImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/DeviceImpl.java
@@ -6,20 +6,17 @@
 package com.dynatrace.openkit.core;
 
 import com.dynatrace.openkit.api.Device;
+import com.dynatrace.openkit.api.OpenKitConstants;
 
 /**
  * Actual implementation of the {@link Device} interface.
  */
 public class DeviceImpl implements Device {
 
-	public static final String DEFAULT_OPERATING_SYSTEM = "OpenKit 0.3";		// 'OpenKit 0.3'
-	public static final String DEFAULT_MANUFACTURER = "Dynatrace";				// default: 'Dynatrace'
-	public static final String DEFAULT_DEVICE_ID = "OpenKitDevice";			// default: 'OpenKitDevice'
-
 	// platform information
-	private String operatingSystem = DEFAULT_OPERATING_SYSTEM;
-	private String manufacturer = DEFAULT_MANUFACTURER;
-	private String modelID = DEFAULT_DEVICE_ID;
+	private String operatingSystem = OpenKitConstants.DEFAULT_OPERATING_SYSTEM;
+	private String manufacturer = OpenKitConstants.DEFAULT_MANUFACTURER;
+	private String modelID = OpenKitConstants.DEFAULT_DEVICE_ID;
 
 	// *** Device interface methods ***
 

--- a/src/main/java/com/dynatrace/openkit/core/configuration/AbstractConfiguration.java
+++ b/src/main/java/com/dynatrace/openkit/core/configuration/AbstractConfiguration.java
@@ -8,6 +8,7 @@ package com.dynatrace.openkit.core.configuration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.dynatrace.openkit.api.OpenKitConstants;
 import com.dynatrace.openkit.core.DeviceImpl;
 import com.dynatrace.openkit.protocol.StatusResponse;
 
@@ -21,7 +22,6 @@ public abstract class AbstractConfiguration {
     private static final int DEFAULT_MAX_BEACON_SIZE = 30 * 1024;                   // default: max 30KB (in B) to send in one beacon
     private static final boolean DEFAULT_CAPTURE_ERRORS = true;                     // default: capture errors on
     private static final boolean DEFAULT_CAPTURE_CRASHES = true;                    // default: capture crashes on
-    private static final String DEFAULT_APPLICATION_VERSION = "0.3";                // default: '0.3'
 
     // immutable settings
     private final String applicationName;
@@ -68,7 +68,7 @@ public abstract class AbstractConfiguration {
         captureCrashes = new AtomicBoolean(DEFAULT_CAPTURE_CRASHES);
 
         device = new DeviceImpl();
-        applicationVersion = DEFAULT_APPLICATION_VERSION;
+        applicationVersion = OpenKitConstants.DEFAULT_APPLICATION_VERSION;
         httpClientConfiguration = null;
     }
 

--- a/src/test/java/com/dynatrace/openkit/test/AbstractAppMonTest.java
+++ b/src/test/java/com/dynatrace/openkit/test/AbstractAppMonTest.java
@@ -7,6 +7,7 @@ package com.dynatrace.openkit.test;
 
 import java.util.ArrayList;
 
+import com.dynatrace.openkit.api.OpenKitConstants;
 import org.junit.Assert;
 
 import com.dynatrace.openkit.protocol.HTTPClient.RequestType;
@@ -18,10 +19,10 @@ public abstract class AbstractAppMonTest extends AbstractTest {
 	public static final String TEST_APPLICATION_ID = "TestApplicationID";
 	public static final String TEST_ENDPOINT = "http://localhost/";
 	public static final String TEST_IP = "123.45.67.89";
-	public static final String TEST_OPENKIT_DEFAULT_VERSION = "0.3";
+	public static final String TEST_OPENKIT_DEFAULT_VERSION = OpenKitConstants.DEFAULT_APPLICATION_VERSION;
 	public static final String TEST_DEVICE_TYPE = "OpenKitDevice";
 	public static final String TEST_MANUFACTURER = "Dynatrace";
-	public static final String TEST_OS = "OpenKit+0.3";
+	public static final String TEST_OS = "OpenKit+" + OpenKitConstants.DEFAULT_APPLICATION_VERSION;
 
 	protected String getDefaultEndpoint() {
 		return TEST_ENDPOINT + "dynaTraceMonitor?type=m&srvid=1&app=" + TEST_APPLICATION_NAME + "&va=7.0.0000&pt=1";

--- a/src/test/java/com/dynatrace/openkit/test/ConfigurationTest.java
+++ b/src/test/java/com/dynatrace/openkit/test/ConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.dynatrace.openkit.test;
 
+import com.dynatrace.openkit.api.OpenKitConstants;
 import com.dynatrace.openkit.core.configuration.AbstractConfiguration;
 import com.dynatrace.openkit.core.configuration.AppMonConfiguration;
 import com.dynatrace.openkit.core.configuration.DynatraceConfiguration;
@@ -15,7 +16,6 @@ public class ConfigurationTest {
     private static final String host = "localhost:9999";
     private static final String tenantId = "asdf";
     private static final String applicationName = "testApp";
-    private static final String applicationVersion = "0.3";
 
     @Test
     public void saasURLIsCorrect() {
@@ -64,6 +64,6 @@ public class ConfigurationTest {
     public void defaultApplicationVersionIsCorrect() {
         AbstractConfiguration configuration = new AppMonConfiguration(applicationName, 17, "", false, new SSLStrictTrustManager());
 
-        assertThat(applicationVersion, is(configuration.getApplicationVersion()));
+        assertThat(configuration.getApplicationVersion(), is(OpenKitConstants.DEFAULT_APPLICATION_VERSION));
     }
 }

--- a/src/test/java/com/dynatrace/openkit/test/DeviceImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/test/DeviceImplTest.java
@@ -1,5 +1,6 @@
 package com.dynatrace.openkit.test;
 
+import com.dynatrace.openkit.api.OpenKitConstants;
 import com.dynatrace.openkit.core.DeviceImpl;
 import org.junit.Test;
 
@@ -12,14 +13,14 @@ public class DeviceImplTest {
     public void defaultValueForModelIdIsCorrect() {
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
     }
 
     @Test
     public void settingModelIdUsingValidValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
 
         String validModelId = "testDevice";
         device.setModelID(validModelId);
@@ -31,38 +32,38 @@ public class DeviceImplTest {
     public void settingModelIdUsingEmptyValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
 
         String emptyModelId = "";
         device.setModelID(emptyModelId);
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
     }
 
     @Test
     public void settingModelIdUsingUndefinedValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
 
         String undefinedModelId = null;
         device.setModelID(undefinedModelId);
 
-        assertThat(DeviceImpl.DEFAULT_DEVICE_ID, is(device.getModelID()));
+        assertThat(OpenKitConstants.DEFAULT_DEVICE_ID, is(device.getModelID()));
     }
 
     @Test
     public void defaultValueForOperatingSystemIsCorrect() {
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
     }
 
     @Test
     public void settingOperatingSystemUsingValidValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
 
         String validModelId = "testDevice";
         device.setOperatingSystem(validModelId);
@@ -74,38 +75,38 @@ public class DeviceImplTest {
     public void settingOperatingSystemUsingEmptyValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
 
         String emptyOperatingSystem = "";
         device.setOperatingSystem(emptyOperatingSystem);
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
     }
 
     @Test
     public void settingOperatingSystemUsingUndefinedValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
 
         String undefinedOperatingSystem = null;
         device.setOperatingSystem(undefinedOperatingSystem);
 
-        assertThat(DeviceImpl.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
+        assertThat(OpenKitConstants.DEFAULT_OPERATING_SYSTEM, is(device.getOperatingSystem()));
     }
 
     @Test
     public void defaultValueForMancufacturerModelIdIsCorrect() {
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
     }
 
     @Test
     public void settingManufacturerUsingValidValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
 
         String validManufacturer = "testManufacturer";
         device.setManufacturer(validManufacturer);
@@ -117,23 +118,23 @@ public class DeviceImplTest {
     public void settingManufacturerUsingEmptyValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
 
         String emptyManufacturer = "";
         device.setManufacturer(emptyManufacturer);
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
     }
 
     @Test
     public void settingManufacturerUsingUndefinedValue(){
         DeviceImpl device = new DeviceImpl();
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
 
         String undefinedManufacturer = null;
         device.setManufacturer(undefinedManufacturer);
 
-        assertThat(DeviceImpl.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
+        assertThat(OpenKitConstants.DEFAULT_MANUFACTURER, is(device.getManufacturer()));
     }
 }


### PR DESCRIPTION
In order to be able to increase the version easily, I introduced a new class OpenKitConstants in the api package. The class contains constants that define default values for the OpenKit config. When creating a new version of OpenKit the DEFAULT_APPLICATION_VERSION has to be set to the current OpenKit version.

The version is used in the default OS which is set to "OpenKit <<DEFAULT_APPLICATION_VERSION >>". 

The new constants are used in test. So tests will not break due to a value change.
