### PR TITLE
Actions on closed/ended/shutdown objects are not possible

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
@@ -69,7 +69,7 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportEvent(String eventName) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             beacon.reportEvent(this, eventName);
         }
         return this;
@@ -77,7 +77,7 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, int value) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
         return this;
@@ -85,7 +85,7 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, double value) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
         return this;
@@ -93,7 +93,7 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, String value) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
         return this;
@@ -101,7 +101,7 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportError(String errorName, int errorCode, String reason) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             beacon.reportError(this, errorName, errorCode, reason);
         }
         return this;
@@ -109,7 +109,7 @@ public class ActionImpl implements Action {
 
     @Override
     public WebRequestTracer traceWebRequest(URLConnection connection) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             return new WebRequestTracerURLConnection(beacon, this, connection);
         }
 
@@ -118,7 +118,7 @@ public class ActionImpl implements Action {
 
     @Override
     public WebRequestTracer traceWebRequest(String url) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             return new WebRequestTracerStringURL(beacon, this, url);
         }
 
@@ -179,8 +179,8 @@ public class ActionImpl implements Action {
         return endSequenceNo;
     }
 
-    boolean isActionOpen() {
-        return getEndTime() == -1;
+    boolean isActionLeft() {
+        return getEndTime() != -1;
     }
 
 }

--- a/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
+++ b/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
@@ -69,7 +69,7 @@ public class BeaconSender {
      * If it's a must to have OpenKit fully initialized use the {@link #waitForInit()} method to wait until initialized.
      * </p>
      */
-    public void initialize() {
+    public synchronized void initialize() {
 
         // create and start the sending thread
         beaconSenderThread = new Thread(new Runnable() {
@@ -120,7 +120,7 @@ public class BeaconSender {
     /**
      * Shutdown the BeaconSender and wait until it's shutdown (at most {@link BeaconSender#SHUTDOWN_TIMEOUT} milliseconds.
      */
-    public void shutdown() {
+    public synchronized void shutdown() {
 
         context.requestShutdown();
 

--- a/src/main/java/com/dynatrace/openkit/core/NullAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullAction.java
@@ -1,0 +1,61 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.Action;
+import com.dynatrace.openkit.api.WebRequestTracer;
+
+import java.net.URLConnection;
+
+class NullAction implements Action {
+
+    private static final WebRequestTracer NULL_TRACER = new NullWebRequestTracer();
+
+    private final Action parentAction;
+
+    NullAction() {
+        this(null);
+    }
+
+    NullAction(Action parentAction) {
+        this.parentAction = parentAction;
+    }
+
+    @Override
+    public Action reportEvent(String eventName) {
+        return this;
+    }
+
+    @Override
+    public Action reportValue(String valueName, int value) {
+        return this;
+    }
+
+    @Override
+    public Action reportValue(String valueName, double value) {
+        return this;
+    }
+
+    @Override
+    public Action reportValue(String valueName, String value) {
+        return this;
+    }
+
+    @Override
+    public Action reportError(String errorName, int errorCode, String reason) {
+        return this;
+    }
+
+    @Override
+    public WebRequestTracer traceWebRequest(URLConnection connection) {
+        return NULL_TRACER;
+    }
+
+    @Override
+    public WebRequestTracer traceWebRequest(String url) {
+        return NULL_TRACER;
+    }
+
+    @Override
+    public Action leaveAction() {
+        return parentAction;
+    }
+}

--- a/src/main/java/com/dynatrace/openkit/core/NullAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullAction.java
@@ -1,20 +1,48 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.dynatrace.openkit.core;
 
 import com.dynatrace.openkit.api.Action;
+import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
 import java.net.URLConnection;
 
+/**
+ * This class is returned as Action by {@link RootAction#enterAction(String)} when the {@link RootAction#leaveAction()}
+ * has been called before.
+ */
 class NullAction implements Action {
 
     private static final WebRequestTracer NULL_TRACER = new NullWebRequestTracer();
 
     private final Action parentAction;
 
+    /**
+     * Construct null action without parent.
+     */
     NullAction() {
         this(null);
     }
 
+    /**
+     * Construct null action with parent action.
+     * @param parentAction
+     */
     NullAction(Action parentAction) {
         this.parentAction = parentAction;
     }

--- a/src/main/java/com/dynatrace/openkit/core/NullRootAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullRootAction.java
@@ -1,0 +1,12 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.Action;
+import com.dynatrace.openkit.api.RootAction;
+
+public class NullRootAction extends NullAction implements RootAction {
+
+    @Override
+    public Action enterAction(String actionName) {
+        return new NullAction(this);
+    }
+}

--- a/src/main/java/com/dynatrace/openkit/core/NullRootAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullRootAction.java
@@ -1,8 +1,29 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.dynatrace.openkit.core;
 
 import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.RootAction;
+import com.dynatrace.openkit.api.Session;
 
+/**
+ * This class is returned as RootAction by {@link Session#enterAction(String)} when the {@link Session#end()}
+ * has been called before.
+ */
 public class NullRootAction extends NullAction implements RootAction {
 
     @Override

--- a/src/main/java/com/dynatrace/openkit/core/NullSession.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullSession.java
@@ -1,8 +1,29 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.dynatrace.openkit.core;
 
+import com.dynatrace.openkit.api.OpenKit;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.Session;
 
+/**
+ * This class is returned as Session by {@link OpenKit#createSession(String)} when the {@link OpenKit#shutdown()}
+ * has been called before.
+ */
 public class NullSession implements Session {
 
     private static final RootAction NULL_ROOT_ACTION = new NullRootAction();

--- a/src/main/java/com/dynatrace/openkit/core/NullSession.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullSession.java
@@ -1,0 +1,29 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.RootAction;
+import com.dynatrace.openkit.api.Session;
+
+public class NullSession implements Session {
+
+    private static final RootAction NULL_ROOT_ACTION = new NullRootAction();
+
+    @Override
+    public RootAction enterAction(String actionName) {
+        return NULL_ROOT_ACTION;
+    }
+
+    @Override
+    public void identifyUser(String userTag) {
+        // intentionally left empty, due to NullObject pattern
+    }
+
+    @Override
+    public void reportCrash(String errorName, String reason, String stacktrace) {
+        // intentionally left empty, due to NullObject pattern
+    }
+
+    @Override
+    public void end() {
+        // intentionally left empty, due to NullObject pattern
+    }
+}

--- a/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
@@ -1,0 +1,36 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.WebRequestTracer;
+
+public class NullWebRequestTracer implements WebRequestTracer {
+
+    @Override
+    public String getTag() {
+        return "";
+    }
+
+    @Override
+    public WebRequestTracer setResponseCode(int responseCode) {
+        return this;
+    }
+
+    @Override
+    public WebRequestTracer setBytesSent(int bytesSent) {
+        return this;
+    }
+
+    @Override
+    public WebRequestTracer setBytesReceived(int bytesReceived) {
+        return this;
+    }
+
+    @Override
+    public WebRequestTracer start() {
+        return this;
+    }
+
+    @Override
+    public void stop() {
+        // intentionally left empty, due to NullObject pattern
+    }
+}

--- a/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
@@ -1,7 +1,29 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.dynatrace.openkit.core;
 
+import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
+/**
+ * This class is returned as WebRequestTracer by {@link Action#traceWebRequest(String)} or
+ * {@link Action#traceWebRequest(java.net.URLConnection)} when the {@link Action#leaveAction()} ()}
+ * has been called before.
+ */
 public class NullWebRequestTracer implements WebRequestTracer {
 
     @Override

--- a/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
@@ -41,7 +41,11 @@ public class RootActionImpl extends ActionImpl implements RootAction {
 
     @Override
     public Action enterAction(String actionName) {
-        return new ActionImpl(beacon, actionName, this, openChildActions);
+        if (isActionOpen()) {
+            return new ActionImpl(beacon, actionName, this, openChildActions);
+        }
+
+        return new NullAction(this);
     }
 
     // *** protected methods ***

--- a/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
@@ -41,7 +41,7 @@ public class RootActionImpl extends ActionImpl implements RootAction {
 
     @Override
     public Action enterAction(String actionName) {
-        if (isActionOpen()) {
+        if (!isActionLeft()) {
             return new ActionImpl(beacon, actionName, this, openChildActions);
         }
 

--- a/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
@@ -124,7 +124,7 @@ public class SessionImpl implements Session {
      *
      * <p>
      * A session is considered to be empty, if it does not contain any action or event data.
-     * </p>e
+     * </p>
      *
      * @return {@code true} if the session is empty, {@code false} otherwise.
      */

--- a/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
@@ -23,13 +23,17 @@ import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.protocol.StatusResponse;
 import com.dynatrace.openkit.providers.HTTPClientProvider;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Actual implementation of the {@link Session} interface.
  */
 public class SessionImpl implements Session {
 
+    private static final RootAction NULL_ROOT_ACTION = new NullRootAction();
+
     // end time of this Session
-    private long endTime = -1;
+    private final AtomicLong endTime = new AtomicLong(-1);
 
     // BeaconSender and Beacon reference
     private final BeaconSender beaconSender;
@@ -51,23 +55,30 @@ public class SessionImpl implements Session {
 
     @Override
     public RootAction enterAction(String actionName) {
+        if (isSessionEnded()) {
+            return NULL_ROOT_ACTION;
+        }
         return new RootActionImpl(beacon, actionName, openRootActions);
     }
 
     @Override
     public void identifyUser(String userTag) {
-        beacon.identifyUser(userTag);
+        if (!isSessionEnded()) {
+            beacon.identifyUser(userTag);
+        }
     }
 
     @Override
     public void reportCrash(String errorName, String reason, String stacktrace) {
-        beacon.reportCrash(errorName, reason, stacktrace);
+        if (!isSessionEnded()) {
+            beacon.reportCrash(errorName, reason, stacktrace);
+        }
     }
 
     @Override
     public void end() {
         // check if end() was already called before by looking at endTime
-        if (endTime != -1) {
+        if (!endTime.compareAndSet(-1L, beacon.getCurrentTimestamp())) {
             return;
         }
 
@@ -76,8 +87,6 @@ public class SessionImpl implements Session {
             Action action = openRootActions.get();
             action.leaveAction();
         }
-
-        endTime = beacon.getCurrentTimestamp();
 
         // create end session data on beacon
         beacon.endSession(this);
@@ -96,7 +105,7 @@ public class SessionImpl implements Session {
     // *** getter methods ***
 
     public long getEndTime() {
-        return endTime;
+        return endTime.get();
     }
 
     /**
@@ -107,7 +116,6 @@ public class SessionImpl implements Session {
      * </p>
      */
     public void clearCapturedData() {
-
         beacon.clearData();
     }
 
@@ -116,11 +124,24 @@ public class SessionImpl implements Session {
      *
      * <p>
      * A session is considered to be empty, if it does not contain any action or event data.
-     * </p>
+     * </p>e
      *
      * @return {@code true} if the session is empty, {@code false} otherwise.
      */
     public boolean isEmpty() {
         return beacon.isEmpty();
+    }
+
+    /**
+     * Test if the session has already been ended.
+     *
+     * <p>
+     * A session is considered as ended, if the endTime is set to something other than minus 1.
+     * </p>
+     *
+     * @return {@code true} if the session has been ended already, {@code false} if the session is not ended yet.
+     */
+    boolean isSessionEnded() {
+        return getEndTime() != -1L;
     }
 }

--- a/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
@@ -25,6 +25,7 @@ import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.providers.ThreadIDProvider;
 import com.dynatrace.openkit.providers.TimingProvider;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -542,9 +543,135 @@ public class ActionImplTest {
         assertThat(action.getParentID(), is(0));
     }
 
+    @Test
+    public void aNewlyCreatedActionIsOpen() {
+
+        // given
+        ActionImpl target = new ActionImpl(createTestBeacon(), "test", new SynchronizedQueue<Action>());
+
+        // then
+        assertThat(target.isActionOpen(), is(true));
+    }
+
+    @Test
+    public void afterLeavingAnActionItIsNotOpen() {
+
+        // given
+        ActionImpl target = new ActionImpl(createTestBeacon(), "test", new SynchronizedQueue<Action>());
+
+        // when
+        target.leaveAction();
+
+        // then
+        assertThat(target.isActionOpen(), is(false));
+    }
+
+    @Test
+    public void reportEventDoesNothingIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+        beacon.clearData();
+
+        // when
+        Action obtained = target.reportEvent("eventName");
+
+        // then
+        assertThat(beacon.isEmpty(), is(true));
+        assertThat(obtained, is(sameInstance((Action)target)));
+    }
+
+    @Test
+    public void reportIntValueDoesNothingIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+        beacon.clearData();
+
+        // when
+        int value = 42;
+        Action obtained = target.reportValue("intValue", value);
+
+        // then
+        assertThat(beacon.isEmpty(), is(true));
+        assertThat(obtained, is(sameInstance((Action)target)));
+    }
+
+    @Test
+    public void reportDoubleValueDoesNothingIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+        beacon.clearData();
+
+        // when
+        double value = 42.0;
+        Action obtained = target.reportValue("doubleValue", value);
+
+        // then
+        assertThat(beacon.isEmpty(), is(true));
+        assertThat(obtained, is(sameInstance((Action)target)));
+    }
+
+    @Test
+    public void reportStringValueDoesNothingIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+        beacon.clearData();
+
+        // when
+        String value = "42";
+        Action obtained = target.reportValue("stringValue", value);
+
+        // then
+        assertThat(beacon.isEmpty(), is(true));
+        assertThat(obtained, is(sameInstance((Action)target)));
+    }
+
+    @Test
+    public void traceWebRequestWithURLConnectionArgumentGivesNullTracerIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+
+        // when
+        WebRequestTracer obtained = target.traceWebRequest(mock(URLConnection.class));
+
+        // then
+        assertThat(obtained, is(notNullValue()));
+        assertThat(obtained, is(instanceOf(NullWebRequestTracer.class)));
+    }
+
+    @Test
+    public void traceWebRequestWithStringArgumentGivesNullTracerIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+
+        // when
+        WebRequestTracer obtained = target.traceWebRequest("http://www.google.com");
+
+        // then
+        assertThat(obtained, is(notNullValue()));
+        assertThat(obtained, is(instanceOf(NullWebRequestTracer.class)));
+    }
+
     private Beacon createTestBeacon() {
         final Logger logger = mock(Logger.class);
-        final BeaconCacheImpl beaconCache = mock(BeaconCacheImpl.class);
+        final BeaconCacheImpl beaconCache = new BeaconCacheImpl();
         final Configuration configuration = mock(Configuration.class);
         when(configuration.getApplicationID()).thenReturn("appID");
         when(configuration.getApplicationName()).thenReturn("appName");

--- a/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
@@ -544,17 +544,17 @@ public class ActionImplTest {
     }
 
     @Test
-    public void aNewlyCreatedActionIsOpen() {
+    public void aNewlyCreatedActionIsNotLeft() {
 
         // given
         ActionImpl target = new ActionImpl(createTestBeacon(), "test", new SynchronizedQueue<Action>());
 
         // then
-        assertThat(target.isActionOpen(), is(true));
+        assertThat(target.isActionLeft(), is(false));
     }
 
     @Test
-    public void afterLeavingAnActionItIsNotOpen() {
+    public void afterLeavingAnActionItIsLeft() {
 
         // given
         ActionImpl target = new ActionImpl(createTestBeacon(), "test", new SynchronizedQueue<Action>());
@@ -563,7 +563,7 @@ public class ActionImplTest {
         target.leaveAction();
 
         // then
-        assertThat(target.isActionOpen(), is(false));
+        assertThat(target.isActionLeft(), is(true));
     }
 
     @Test

--- a/src/test/java/com/dynatrace/openkit/core/OpenKitImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/OpenKitImplTest.java
@@ -21,6 +21,8 @@ import com.dynatrace.openkit.api.Session;
 import com.dynatrace.openkit.core.configuration.Configuration;
 import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -226,5 +228,21 @@ public class OpenKitImplTest {
 
         // verify that the two sessions exist and are not the same
         assertThat(session1impl, not(sameInstance(session2impl)));
+    }
+
+    @Test
+    public void anAlreadyShutdownOpenKitCreatesANullSession() {
+
+        // given
+        OpenKitImpl target = new OpenKitImpl(logger, config);
+        target.initialize();
+        target.shutdown();
+
+        // when
+        Session obtained = target.createSession("127.0.0.1");
+
+        // then
+        assertThat(obtained, is(notNullValue()));
+        assertThat(obtained, is(instanceOf(NullSession.class)));
     }
 }

--- a/src/test/java/com/dynatrace/openkit/core/RootActionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/RootActionImplTest.java
@@ -19,7 +19,10 @@ package com.dynatrace.openkit.core;
 import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.protocol.Beacon;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+
+import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.*;
@@ -95,7 +98,7 @@ public class RootActionImplTest {
         assertThat(rootAction, is(instanceOf(ActionImpl.class)));
         assertThat(childAction1, is(instanceOf(ActionImpl.class)));
         assertThat(childAction2, is(instanceOf(ActionImpl.class)));
-        assertThat(((ActionImpl) rootAction).getName(), is(rootActionStr));
+        assertThat(rootAction.getName(), is(rootActionStr));
         assertThat(((ActionImpl) childAction1).getName(), is(childOneActionStr));
         assertThat(((ActionImpl) childAction2).getName(), is(childTwoActionStr));
 
@@ -103,5 +106,20 @@ public class RootActionImplTest {
         final Action retAction = rootAction.leaveAction();
         assertThat(retAction, is(nullValue()));
         assertThat(actions.toArrayList().isEmpty(), is(true));
+    }
+
+    @Test
+    public void enterActionGivesNullActionIfAlreadyLeft() {
+
+        // given
+        RootActionImpl target = new RootActionImpl(mock(Beacon.class), "parent action", new SynchronizedQueue<Action>());
+        target.leaveAction();
+
+        // when
+        Action obtained = target.enterAction("child action");
+
+        // then
+        assertThat(obtained, is(notNullValue()));
+        assertThat(obtained, is(instanceOf(NullAction.class)));
     }
 }

--- a/src/test/java/com/dynatrace/openkit/core/WebRequestTracerBaseImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/WebRequestTracerBaseImplTest.java
@@ -1,0 +1,229 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.WebRequestTracer;
+import com.dynatrace.openkit.protocol.Beacon;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
+
+public class WebRequestTracerBaseImplTest {
+
+    private Beacon mockBeacon;
+    private ActionImpl mockActionImpl;
+
+    private static final int SEQUENCE_NUMBER = 1234;
+    private static final String TAG = "THE_TAG";
+
+    @Before
+    public void setUp() {
+        mockBeacon = mock(Beacon.class);
+        mockActionImpl = mock(ActionImpl.class);
+
+        when(mockBeacon.createSequenceNumber()).thenReturn(SEQUENCE_NUMBER);
+        when(mockBeacon.createTag(org.mockito.Matchers.any(ActionImpl.class), anyInt())).thenReturn(TAG);
+    }
+
+    @Test
+    public void defaultValues() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // then
+        assertThat(target.getURL(), is("<unknown>"));
+        assertThat(target.getResponseCode(), is(-1));
+        assertThat(target.getStartTime(), is(-1L));
+        assertThat(target.getEndTime(), is(-1L));
+        assertThat(target.getStartSequenceNo(), is(SEQUENCE_NUMBER));
+        assertThat(target.getEndSequenceNo(), is(-1));
+        assertThat(target.getBytesSent(), is(-1));
+        assertThat(target.getBytesReceived(), is(-1));
+
+        // and verify that the sequence number was retrieved from beacon, as well as the tag
+        verify(mockBeacon, times(1)).createSequenceNumber();
+        verify(mockBeacon, times(1)).createTag(mockActionImpl, SEQUENCE_NUMBER);
+    }
+
+    @Test
+    public void getTag() {
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // then
+        assertThat(target.getTag(), is(TAG));
+    }
+
+    @Test
+    public void aNewlyCreatedWebRequestTracerIsNotStopped() {
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // then
+        assertThat(target.isStopped(), is(false));
+    }
+
+    @Test
+    public void aWebRequestTracerIsStoppedAfterStopHasBeenCalled() {
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // when calling the stop method
+        target.stop();
+
+        // then
+        assertThat(target.isStopped(), is(true));
+    }
+
+    @Test
+    public void setResponseCodeSetsTheResponseCode() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // when setting response code
+        WebRequestTracer obtained = target.setResponseCode(418);
+
+        // then
+        assertThat(target.getResponseCode(), is(418));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void setResponseCodeDoesNotSetTheResponseCodeIfStopped() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        target.stop();
+
+        // when setting response code
+        WebRequestTracer obtained = target.setResponseCode(418);
+
+        // then
+        assertThat(target.getResponseCode(), is(-1));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void setBytesSentSetsTheNumberOfSentBytes() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // when setting the sent bytes
+        WebRequestTracer obtained = target.setBytesSent(1234);
+
+        // then
+        assertThat(target.getBytesSent(), is(1234));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void setBytesSentDoesNotSetAnythingIfStopped() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        target.stop();
+
+        // when setting the sent bytes
+        WebRequestTracer obtained = target.setBytesSent(1234);
+
+        // then
+        assertThat(target.getBytesSent(), is(-1));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void setBytesReceivedSetsTheNumberOfReceivedBytes() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+
+        // when setting the received bytes
+        WebRequestTracer obtained = target.setBytesReceived(4321);
+
+        // then
+        assertThat(target.getBytesReceived(), is(4321));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void setBytesReceivedDoesNotSetAnythingIfStopped() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        target.stop();
+
+        // when setting the received bytes
+        WebRequestTracer obtained = target.setBytesReceived(4321);
+
+        // then
+        assertThat(target.getBytesReceived(), is(-1));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void startSetsTheStartTime() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        when(mockBeacon.getCurrentTimestamp()).thenReturn(123456789L);
+
+        // when starting web request tracing
+        WebRequestTracer obtained = target.start();
+
+        // then
+        assertThat(target.getStartTime(), is(123456789L));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void startDoesNothingIfAlreadyStopped() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        when(mockBeacon.getCurrentTimestamp()).thenReturn(123456789L);
+        target.stop();
+
+        // when starting web request tracing
+        WebRequestTracer obtained = target.start();
+
+        // then
+        assertThat(target.getStartTime(), is(-1L));
+        assertThat(obtained, is(sameInstance((WebRequestTracer)target)));
+    }
+
+    @Test
+    public void stopCanOnlyBeExecutedOnce() {
+
+        // given
+        WebRequestTracerBaseImpl target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        when(mockBeacon.createSequenceNumber()).thenReturn(42);
+
+        // when executed the first time
+        target.stop();
+
+        // then
+        assertThat(target.getEndSequenceNo(), is(42));
+        verify(mockBeacon, times(2)).createSequenceNumber();
+        verify(mockBeacon, times(1)).addWebRequest(mockActionImpl, target);
+
+        // and when executed the second time
+        target.stop();
+
+        // then
+        verify(mockBeacon, times(2)).createSequenceNumber();
+        verify(mockBeacon, times(1)).addWebRequest(mockActionImpl, target);
+    }
+
+    private static final class TestWebRequestTracerBaseImpl extends WebRequestTracerBaseImpl {
+
+        public TestWebRequestTracerBaseImpl(Beacon beacon, ActionImpl action) {
+            super(beacon, action);
+        }
+    }
+}

--- a/src/test/java/com/dynatrace/openkit/core/WebRequestTracerURLConnectionTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/WebRequestTracerURLConnectionTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 /**
- * Tests the {@link WebRequestTracerBaseImpl} implementation having knowledge of the code.
+ * Tests the {@link WebRequestTracerBaseImplTest} implementation having knowledge of the code.
  */
 public class WebRequestTracerURLConnectionTest {
 

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -387,7 +387,7 @@ public class BeaconTest {
                 new NullTimeProvider());
         ActionImpl action = mock(ActionImpl.class);
         when(action.getID()).thenReturn(ACTION_ID);
-        WebRequestTracerBaseImpl webRequestTracer = mock(WebRequestTracerURLConnection.class);
+        WebRequestTracerURLConnection webRequestTracer = mock(WebRequestTracerURLConnection.class);
         when(webRequestTracer.getBytesSent()).thenReturn(13);
         when(webRequestTracer.getBytesReceived()).thenReturn(14);
         when(webRequestTracer.getResponseCode()).thenReturn(15);


### PR DESCRIPTION
It is no longer possible to perform actions on already closed/left/shutdown objects.

This includes
- OpenKit
- Session
- Action
- WebRequestTracer
