### PR TITLE
Add additional test for reportError

### DIFF
--- a/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
@@ -638,6 +638,23 @@ public class ActionImplTest {
     }
 
     @Test
+    public void reportErrorDoesNothingIfActionIsLeft() {
+
+        // given
+        Beacon beacon = createTestBeacon();
+        ActionImpl target = new ActionImpl(beacon, "test", new SynchronizedQueue<Action>());
+        target.leaveAction();
+        beacon.clearData();
+
+        // when
+        Action obtained = target.reportError("teapot", 418, "I'm a teapot");
+
+        // then
+        assertThat(beacon.isEmpty(), is(true));
+        assertThat(obtained, is(sameInstance((Action)target)));
+    }
+
+    @Test
     public void traceWebRequestWithURLConnectionArgumentGivesNullTracerIfActionIsLeft() {
 
         // given


### PR DESCRIPTION
When an Action has been left, it shall be no longer possible to report an error on that action. The behavior was implemented already, but a test to ensure that behavior was missing. This has been fixed with this PR.