### PR TITLE
Rename Logger.warning to Logger.warn

### DIFF
--- a/src/main/java/com/dynatrace/openkit/api/Logger.java
+++ b/src/main/java/com/dynatrace/openkit/api/Logger.java
@@ -42,7 +42,7 @@ public interface Logger {
      *
      * @param message the message to write to the log
      */
-    void warning(String message);
+    void warn(String message);
 
     /**
      * Log with level 'info'
@@ -85,6 +85,4 @@ public interface Logger {
      * @return true if 'debug' level messages are printed, 'false' if not
      */
     boolean isDebugEnabled();
-
-
 }

--- a/src/main/java/com/dynatrace/openkit/core/caching/BeaconCacheEvictor.java
+++ b/src/main/java/com/dynatrace/openkit/core/caching/BeaconCacheEvictor.java
@@ -116,7 +116,7 @@ public class BeaconCacheEvictor {
                 evictionThread.join(timeout);
                 result = !isAlive();
             } catch (InterruptedException e) {
-                logger.warning("Stopping BeaconCacheEviction thread was interrupted.");
+                logger.warn("Stopping BeaconCacheEviction thread was interrupted.");
                 Thread.currentThread().interrupt(); // re-interrupt the current thread
             }
         } else {

--- a/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
+++ b/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
@@ -59,7 +59,7 @@ public class DefaultLogger implements Logger {
     }
 
     @Override
-    public void warning(String message) {
+    public void warn(String message) {
         System.out.println(getUTCTime() + " [WARN ] " + message);
     }
 

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -245,7 +245,7 @@ public class BeaconTest {
 
         // then (verify, that calling reportValue with a null value doesn't throw an exception but instead only triggers a warning)
         assertThat(events, emptyArray());
-        verify(logger, times(1)).warning(anyString());
+        verify(logger, times(1)).warn(anyString());
     }
 
     @Ignore
@@ -265,7 +265,7 @@ public class BeaconTest {
 
         // then (verify, that calling reportValue with a null name and null value does throw an exception)
         assertThat(events, emptyArray());
-        verify(logger, times(1)).warning(anyString());
+        verify(logger, times(1)).warn(anyString());
     }
 
     @Test


### PR DESCRIPTION
The renaming is performed in order to be consistent with the
.NET implementation.