### PR TITLE
OpenKit interfaces extend java.io.Closeable

### DIFF
--- a/src/main/java/com/dynatrace/openkit/api/Action.java
+++ b/src/main/java/com/dynatrace/openkit/api/Action.java
@@ -16,12 +16,13 @@
 
 package com.dynatrace.openkit.api;
 
+import java.io.Closeable;
 import java.net.URLConnection;
 
 /**
  * This interface provides functionality to create (child) Actions, report events/values/errors and tracing web requests.
  */
-public interface Action {
+public interface Action extends Closeable {
 
     /**
      * Reports an event with a specified name (but without any value).

--- a/src/main/java/com/dynatrace/openkit/api/OpenKit.java
+++ b/src/main/java/com/dynatrace/openkit/api/OpenKit.java
@@ -16,10 +16,12 @@
 
 package com.dynatrace.openkit.api;
 
+import java.io.Closeable;
+
 /**
  * This interface provides basic OpenKit functionality, like creating a Session and shutting down OpenKit.
  */
-public interface OpenKit {
+public interface OpenKit extends Closeable {
 
     /**
      * Waits until OpenKit is fully initialized.

--- a/src/main/java/com/dynatrace/openkit/api/Session.java
+++ b/src/main/java/com/dynatrace/openkit/api/Session.java
@@ -16,10 +16,12 @@
 
 package com.dynatrace.openkit.api;
 
+import java.io.Closeable;
+
 /**
  * This interface provides functionality to create Actions in a Session.
  */
-public interface Session {
+public interface Session extends Closeable {
 
     /**
      * Enters an Action with a specified name in this Session.

--- a/src/main/java/com/dynatrace/openkit/api/WebRequestTracer.java
+++ b/src/main/java/com/dynatrace/openkit/api/WebRequestTracer.java
@@ -16,10 +16,12 @@
 
 package com.dynatrace.openkit.api;
 
+import java.io.Closeable;
+
 /**
  * This interface allows tracing and timing of a web request.
  */
-public interface WebRequestTracer {
+public interface WebRequestTracer extends Closeable {
 
     /**
      * Returns the Dynatrace tag which has to be set manually as Dynatrace HTTP header

--- a/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
@@ -20,6 +20,7 @@ import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.WebRequestTracer;
 import com.dynatrace.openkit.protocol.Beacon;
 
+import java.io.IOException;
 import java.net.URLConnection;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -66,6 +67,12 @@ public class ActionImpl implements Action {
     }
 
     // *** Action interface methods ***
+
+
+    @Override
+    public void close() {
+        leaveAction();
+    }
 
     @Override
     public Action reportEvent(String eventName) {

--- a/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
@@ -20,7 +20,6 @@ import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.WebRequestTracer;
 import com.dynatrace.openkit.protocol.Beacon;
 
-import java.io.IOException;
 import java.net.URLConnection;
 import java.util.concurrent.atomic.AtomicLong;
 

--- a/src/main/java/com/dynatrace/openkit/core/NullAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullAction.java
@@ -20,6 +20,7 @@ import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
+import java.io.IOException;
 import java.net.URLConnection;
 
 /**
@@ -85,5 +86,10 @@ class NullAction implements Action {
     @Override
     public Action leaveAction() {
         return parentAction;
+    }
+
+    @Override
+    public void close() {
+        leaveAction();
     }
 }

--- a/src/main/java/com/dynatrace/openkit/core/NullAction.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullAction.java
@@ -20,7 +20,6 @@ import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
-import java.io.IOException;
 import java.net.URLConnection;
 
 /**
@@ -42,7 +41,7 @@ class NullAction implements Action {
 
     /**
      * Construct null action with parent action.
-     * @param parentAction
+     * @param parentAction The parent action, which might be {@code null}.
      */
     NullAction(Action parentAction) {
         this.parentAction = parentAction;

--- a/src/main/java/com/dynatrace/openkit/core/NullSession.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullSession.java
@@ -20,8 +20,6 @@ import com.dynatrace.openkit.api.OpenKit;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.Session;
 
-import java.io.IOException;
-
 /**
  * This class is returned as Session by {@link OpenKit#createSession(String)} when the {@link OpenKit#shutdown()}
  * has been called before.

--- a/src/main/java/com/dynatrace/openkit/core/NullSession.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullSession.java
@@ -20,6 +20,8 @@ import com.dynatrace.openkit.api.OpenKit;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.api.Session;
 
+import java.io.IOException;
+
 /**
  * This class is returned as Session by {@link OpenKit#createSession(String)} when the {@link OpenKit#shutdown()}
  * has been called before.
@@ -46,5 +48,10 @@ public class NullSession implements Session {
     @Override
     public void end() {
         // intentionally left empty, due to NullObject pattern
+    }
+
+    @Override
+    public void close() {
+        end();
     }
 }

--- a/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
@@ -19,6 +19,8 @@ package com.dynatrace.openkit.core;
 import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
+import java.io.IOException;
+
 /**
  * This class is returned as WebRequestTracer by {@link Action#traceWebRequest(String)} or
  * {@link Action#traceWebRequest(java.net.URLConnection)} when the {@link Action#leaveAction()} ()}
@@ -54,5 +56,10 @@ public class NullWebRequestTracer implements WebRequestTracer {
     @Override
     public void stop() {
         // intentionally left empty, due to NullObject pattern
+    }
+
+    @Override
+    public void close() {
+        stop();
     }
 }

--- a/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
+++ b/src/main/java/com/dynatrace/openkit/core/NullWebRequestTracer.java
@@ -19,8 +19,6 @@ package com.dynatrace.openkit.core;
 import com.dynatrace.openkit.api.Action;
 import com.dynatrace.openkit.api.WebRequestTracer;
 
-import java.io.IOException;
-
 /**
  * This class is returned as WebRequestTracer by {@link Action#traceWebRequest(String)} or
  * {@link Action#traceWebRequest(java.net.URLConnection)} when the {@link Action#leaveAction()} ()}

--- a/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
@@ -25,6 +25,7 @@ import com.dynatrace.openkit.core.configuration.Configuration;
 import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.providers.*;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -82,6 +83,12 @@ public class OpenKitImpl implements OpenKit {
     }
 
     // *** OpenKit interface methods ***
+
+
+    @Override
+    public void close() {
+        shutdown();
+    }
 
     @Override
     public boolean waitForInitCompletion() {

--- a/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
@@ -25,7 +25,6 @@ import com.dynatrace.openkit.core.configuration.Configuration;
 import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.providers.*;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**

--- a/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
@@ -23,7 +23,6 @@ import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.protocol.StatusResponse;
 import com.dynatrace.openkit.providers.HTTPClientProvider;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**

--- a/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
@@ -23,6 +23,7 @@ import com.dynatrace.openkit.protocol.Beacon;
 import com.dynatrace.openkit.protocol.StatusResponse;
 import com.dynatrace.openkit.providers.HTTPClientProvider;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -52,6 +53,12 @@ public class SessionImpl implements Session {
     }
 
     // *** Session interface methods ***
+
+
+    @Override
+    public void close() {
+        end();
+    }
 
     @Override
     public RootAction enterAction(String actionName) {

--- a/src/main/java/com/dynatrace/openkit/core/WebRequestTracerBaseImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/WebRequestTracerBaseImpl.java
@@ -19,7 +19,6 @@ package com.dynatrace.openkit.core;
 import com.dynatrace.openkit.api.WebRequestTracer;
 import com.dynatrace.openkit.protocol.Beacon;
 
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -39,7 +38,7 @@ public abstract class WebRequestTracerBaseImpl implements WebRequestTracer {
     // start/end time & sequence number
     private long startTime = -1;
     private final AtomicLong endTime = new AtomicLong(-1);
-    private int startSequenceNo = -1;
+    private int startSequenceNo;
     private int endSequenceNo = -1;
 
     // Beacon and Action references
@@ -48,7 +47,7 @@ public abstract class WebRequestTracerBaseImpl implements WebRequestTracer {
 
     // *** constructors ***
 
-    public WebRequestTracerBaseImpl(Beacon beacon, ActionImpl action) {
+    WebRequestTracerBaseImpl(Beacon beacon, ActionImpl action) {
         this.beacon = beacon;
         this.action = action;
 

--- a/src/main/java/com/dynatrace/openkit/core/WebRequestTracerBaseImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/WebRequestTracerBaseImpl.java
@@ -19,6 +19,7 @@ package com.dynatrace.openkit.core;
 import com.dynatrace.openkit.api.WebRequestTracer;
 import com.dynatrace.openkit.protocol.Beacon;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -106,6 +107,11 @@ public abstract class WebRequestTracerBaseImpl implements WebRequestTracer {
 
         // add web request to beacon
         beacon.addWebRequest(action, this);
+    }
+
+    @Override
+    public void close() {
+        stop();
     }
 
     // *** getter methods ***

--- a/src/test/java/com/dynatrace/openkit/core/SessionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/SessionImplTest.java
@@ -32,6 +32,9 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -446,5 +449,20 @@ public class SessionImplTest {
 
         // then
         assertThat(session.isEmpty(), is(true));
+    }
+
+    @Test
+    public void closeSessionEndsTheSession() throws IOException {
+
+        // given
+        Closeable target = new SessionImpl(beaconSender, beacon);
+        beacon.clearData();
+
+        // when
+        target.close();
+
+        // then
+        assertThat(beacon.isEmpty(), is(false));
+        verify(beaconSender, times(1)).finishSession((SessionImpl)target);
     }
 }

--- a/src/test/java/com/dynatrace/openkit/core/WebRequestTracerBaseImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/WebRequestTracerBaseImplTest.java
@@ -5,6 +5,9 @@ import com.dynatrace.openkit.protocol.Beacon;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
@@ -218,6 +221,22 @@ public class WebRequestTracerBaseImplTest {
         // then
         verify(mockBeacon, times(2)).createSequenceNumber();
         verify(mockBeacon, times(1)).addWebRequest(mockActionImpl, target);
+    }
+
+    @Test
+    public void closingAWebRequestStopsIt() throws IOException {
+
+        // given
+        Closeable target = new TestWebRequestTracerBaseImpl(mockBeacon, mockActionImpl);
+        when(mockBeacon.createSequenceNumber()).thenReturn(42);
+
+        // when executed the first time
+        target.close();
+
+        // then
+        assertThat(((WebRequestTracerBaseImpl)target).getEndSequenceNo(), is(42));
+        verify(mockBeacon, times(2)).createSequenceNumber();
+        verify(mockBeacon, times(1)).addWebRequest(mockActionImpl, (WebRequestTracerBaseImpl)target);
     }
 
     private static final class TestWebRequestTracerBaseImpl extends WebRequestTracerBaseImpl {


### PR DESCRIPTION
Extending the java.io.Closeable allows an OpenKit user
to wrap OpenKit objects in a try-with-resources block
guaranteeing that all objects are closed/left/ended.