### PR TITLE
Prevent reporting of null arguments

### DIFF
--- a/src/main/java/com/dynatrace/openkit/api/Action.java
+++ b/src/main/java/com/dynatrace/openkit/api/Action.java
@@ -27,6 +27,10 @@ public interface Action extends Closeable {
     /**
      * Reports an event with a specified name (but without any value).
      *
+     * <p>
+     *     If given {@code eventName} is {@code null} then no event is reported to the system.
+     * </p>
+     *
      * @param eventName name of the event
      * @return this Action (for usage as fluent API)
      */

--- a/src/main/java/com/dynatrace/openkit/api/RootAction.java
+++ b/src/main/java/com/dynatrace/openkit/api/RootAction.java
@@ -24,6 +24,11 @@ public interface RootAction extends Action {
     /**
      * Enters a (child) Action with a specified name on this Action.
      *
+     * <p>
+     *     If the given {@code actionName} is {@code null} or an empty string,
+     *     no reporting will happen on that {@link RootAction}.
+     * </p>
+     *
      * @param actionName name of the Action
      * @return Action instance to work with
      */

--- a/src/main/java/com/dynatrace/openkit/api/Session.java
+++ b/src/main/java/com/dynatrace/openkit/api/Session.java
@@ -26,6 +26,11 @@ public interface Session extends Closeable {
     /**
      * Enters an Action with a specified name in this Session.
      *
+     * <p>
+     *     If the given {@code actionName} is {@code null} or an empty string,
+     *     no reporting will happen on that {@link RootAction}.
+     * </p>
+     *
      * @param actionName name of the Action
      * @return Action instance to work with
      */
@@ -34,12 +39,22 @@ public interface Session extends Closeable {
     /**
      * Tags a session with the provided {@code userTag}.
      *
+     * <p>
+     *     If the given {@code userTag} is {@code null} or an empty string,
+     *     no user identification will be reported to the server.
+     * </p>
+     *
      * @param userTag id of the user
      */
     void identifyUser(String userTag);
 
     /**
      * Reports a crash with a specified error name, crash reason and a stacktrace.
+     *
+     * <p>
+     *     If the given {@code errorName} is {@code null} or an empty string,
+     *     no crash report will be sent to the server.
+     * </p>
      *
      * @param errorName  name of the error leading to the crash (e.g. Exception class)
      * @param reason     reason or description of that error

--- a/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
@@ -17,6 +17,7 @@
 package com.dynatrace.openkit.core;
 
 import com.dynatrace.openkit.api.Action;
+import com.dynatrace.openkit.api.Logger;
 import com.dynatrace.openkit.api.WebRequestTracer;
 import com.dynatrace.openkit.protocol.Beacon;
 
@@ -29,6 +30,9 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ActionImpl implements Action {
 
     private static final WebRequestTracer NULL_WEB_REQUEST_TRACER = new NullWebRequestTracer();
+
+    // logger
+    private final Logger logger;
 
     // Action ID, name and parent ID (default: null)
     private final int id;
@@ -48,11 +52,13 @@ public class ActionImpl implements Action {
 
     // *** constructors ***
 
-    ActionImpl(Beacon beacon, String name, SynchronizedQueue<Action> thisLevelActions) {
-        this(beacon, name, null, thisLevelActions);
+    ActionImpl(Logger logger, Beacon beacon, String name, SynchronizedQueue<Action> thisLevelActions) {
+        this(logger, beacon, name, null, thisLevelActions);
     }
 
-    ActionImpl(Beacon beacon, String name, ActionImpl parentAction, SynchronizedQueue<Action> thisLevelActions) {
+    ActionImpl(Logger logger, Beacon beacon, String name, ActionImpl parentAction, SynchronizedQueue<Action> thisLevelActions) {
+        this.logger = logger;
+
         this.beacon = beacon;
         this.parentAction = parentAction;
 
@@ -75,6 +81,10 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportEvent(String eventName) {
+        if (eventName == null || eventName.isEmpty()) {
+            logger.warning("Action.reportEvent: eventName must not be null or empty");
+            return this;
+        }
         if (!isActionLeft()) {
             beacon.reportEvent(this, eventName);
         }
@@ -83,6 +93,10 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, int value) {
+        if (valueName == null || valueName.isEmpty()) {
+            logger.warning("Action.reportValue (int): valueName must not be null or empty");
+            return this;
+        }
         if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
@@ -91,6 +105,10 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, double value) {
+        if (valueName == null || valueName.isEmpty()) {
+            logger.warning("Action.reportValue (double): valueName must not be null or empty");
+            return this;
+        }
         if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
@@ -99,6 +117,10 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportValue(String valueName, String value) {
+        if (valueName == null || valueName.isEmpty()) {
+            logger.warning("Action.reportValue (string): valueName must not be null or empty");
+            return this;
+        }
         if (!isActionLeft()) {
             beacon.reportValue(this, valueName, value);
         }
@@ -107,6 +129,10 @@ public class ActionImpl implements Action {
 
     @Override
     public Action reportError(String errorName, int errorCode, String reason) {
+        if (errorName == null || errorName.isEmpty()) {
+            logger.warning("Action.reportError: errorName must not be null or empty");
+            return this;
+        }
         if (!isActionLeft()) {
             beacon.reportError(this, errorName, errorCode, reason);
         }
@@ -115,6 +141,10 @@ public class ActionImpl implements Action {
 
     @Override
     public WebRequestTracer traceWebRequest(URLConnection connection) {
+        if (connection == null) {
+            logger.warning("Action.traceWebRequest (URLConnection): connection must not be null");
+            return NULL_WEB_REQUEST_TRACER;
+        }
         if (!isActionLeft()) {
             return new WebRequestTracerURLConnection(beacon, this, connection);
         }
@@ -124,6 +154,10 @@ public class ActionImpl implements Action {
 
     @Override
     public WebRequestTracer traceWebRequest(String url) {
+        if (url == null || url.isEmpty()) {
+            logger.warning("Action.traceWebRequest (String): url must not be null or empty");
+            return NULL_WEB_REQUEST_TRACER;
+        }
         if (!isActionLeft()) {
             return new WebRequestTracerStringURL(beacon, this, url);
         }
@@ -189,4 +223,7 @@ public class ActionImpl implements Action {
         return getEndTime() != -1;
     }
 
+    Logger getLogger() {
+        return logger;
+    }
 }

--- a/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/OpenKitImpl.java
@@ -116,7 +116,7 @@ public class OpenKitImpl implements OpenKit {
         // create beacon for session
         Beacon beacon = new Beacon(logger, beaconCache, configuration, clientIPAddress, threadIDProvider, timingProvider);
         // create session
-        return new SessionImpl(beaconSender, beacon);
+        return new SessionImpl(logger, beaconSender, beacon);
     }
 
     @Override

--- a/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/RootActionImpl.java
@@ -17,6 +17,7 @@
 package com.dynatrace.openkit.core;
 
 import com.dynatrace.openkit.api.Action;
+import com.dynatrace.openkit.api.Logger;
 import com.dynatrace.openkit.api.RootAction;
 import com.dynatrace.openkit.protocol.Beacon;
 
@@ -32,8 +33,8 @@ public class RootActionImpl extends ActionImpl implements RootAction {
 
     // *** constructors ***
 
-    RootActionImpl(Beacon beacon, String name, SynchronizedQueue<Action> parentActions) {
-        super(beacon, name, parentActions);
+    RootActionImpl(Logger logger, Beacon beacon, String name, SynchronizedQueue<Action> parentActions) {
+        super(logger, beacon, name, parentActions);
         this.beacon = beacon;
     }
 
@@ -41,8 +42,12 @@ public class RootActionImpl extends ActionImpl implements RootAction {
 
     @Override
     public Action enterAction(String actionName) {
+        if (actionName == null || actionName.isEmpty()) {
+            getLogger().warning("RootAction.enterAction: actionName must not be null or empty");
+            return new NullAction(this);
+        }
         if (!isActionLeft()) {
-            return new ActionImpl(beacon, actionName, this, openChildActions);
+            return new ActionImpl(getLogger(), beacon, actionName, this, openChildActions);
         }
 
         return new NullAction(this);

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -316,7 +316,9 @@ public class Beacon {
         StringBuilder eventBuilder = new StringBuilder();
 
         long eventTimestamp = buildEvent(eventBuilder, EventType.VALUE_STRING, valueName, parentAction);
-        addKeyValuePair(eventBuilder, BEACON_KEY_VALUE, truncate(value));
+        if (value != null) {
+            addKeyValuePair(eventBuilder, BEACON_KEY_VALUE, truncate(value));
+        }
 
         addEventData(eventTimestamp, eventBuilder);
     }
@@ -366,7 +368,9 @@ public class Beacon {
         addKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, createSequenceNumber());
         addKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, getTimeSinceSessionStartTime(timestamp));
         addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_CODE, errorCode);
-        addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+        if (reason != null) {
+            addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+        }
 
         addEventData(timestamp, eventBuilder);
     }
@@ -396,8 +400,12 @@ public class Beacon {
         addKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);                                  // no parent action
         addKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, createSequenceNumber());
         addKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, getTimeSinceSessionStartTime(timestamp));
-        addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
-        addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_STACKTRACE, stacktrace);
+        if (reason != null) {
+            addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_REASON, reason);
+        }
+        if (stacktrace != null) {
+            addKeyValuePair(eventBuilder, BEACON_KEY_ERROR_STACKTRACE, stacktrace);
+        }
 
         addEventData(timestamp, eventBuilder);
     }
@@ -600,7 +608,7 @@ public class Beacon {
     }
 
     /**
-     * Serializeation for building basic event data.
+     * Serialization for building basic event data.
      *
      * @param builder String builder storing serialized data.
      * @param eventType The event's type.

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -228,7 +228,6 @@ public class BeaconTest {
                 "et=11&na=" + valueName + "&it=" + THREAD_ID + "&pa=" + ACTION_ID + "&s0=1&t0=0&vl=" + value })));
     }
 
-    @Ignore
     @Test
     public void reportValueStringWithValueNull() {
         // given
@@ -243,12 +242,10 @@ public class BeaconTest {
         beacon.reportValue(action, valueName, value);
         String[] events = beacon.getEvents();
 
-        // then (verify, that calling reportValue with a null value doesn't throw an exception but instead only triggers a warning)
-        assertThat(events, emptyArray());
-        verify(logger, times(1)).warning(anyString());
+        // then
+        assertThat(events, is(equalTo(new String[] { "et=11&na=StringValue&it=111222333&pa=17&s0=1&t0=0" } )));
     }
 
-    @Ignore
     @Test
     public void reportValueStringWithValueNullAndNameNull() {
         // given
@@ -263,9 +260,8 @@ public class BeaconTest {
         beacon.reportValue(action, valueName, value);
         String[] events = beacon.getEvents();
 
-        // then (verify, that calling reportValue with a null name and null value does throw an exception)
-        assertThat(events, emptyArray());
-        verify(logger, times(1)).warning(anyString());
+        // then
+        assertThat(events, is(equalTo(new String[] { "et=11&it=111222333&pa=17&s0=1&t0=0" } )));
     }
 
     @Test
@@ -362,13 +358,12 @@ public class BeaconTest {
                 + "&pa=0&s0=1&t0=0&rs=" + reason + "&st=" + stacktrace })));
     }
 
-    @Ignore
     @Test
     public void reportCrashWithDetailsNull() {
         // given
         final Beacon beacon = new Beacon(logger, new BeaconCacheImpl(), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String errorName = null;
+        String errorName = "errorName";
         String reason = null;
         String stacktrace = null;
 
@@ -377,7 +372,7 @@ public class BeaconTest {
         String[] events = beacon.getEvents();
 
         // then
-        assertThat(events, is(equalTo(new String[] { "et=50&it=" + THREAD_ID + "&pa=0&s0=1&t0=0" })));
+        assertThat(events, is(equalTo(new String[] { "et=50&na=" + errorName + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0" })));
     }
 
     @Test


### PR DESCRIPTION
All arguments causing troubles are checked, a warning log is generated and OpenKit does nothing or gives back "Null Objects" (see NullObject pattern).