### PR TITLE
Validate URL schemas when tracing web requests

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/ActionImpl.java
@@ -177,6 +177,10 @@ public class ActionImpl implements Action {
             logger.warning(this + "traceWebRequest (String): url must not be null or empty");
             return NULL_WEB_REQUEST_TRACER;
         }
+        if (!WebRequestTracerStringURL.isValidURLScheme(url)) {
+            logger.warning(this + "traceWebRequest (String): url \"" + url + "\" does not have a valid scheme");
+            return NULL_WEB_REQUEST_TRACER;
+        }
         if (logger.isDebugEnabled()) {
             logger.debug(this + "traceWebRequest (String) (" + url + ")");
         }

--- a/src/main/java/com/dynatrace/openkit/core/WebRequestTracerStringURL.java
+++ b/src/main/java/com/dynatrace/openkit/core/WebRequestTracerStringURL.java
@@ -20,11 +20,16 @@ import com.dynatrace.openkit.api.Logger;
 import com.dynatrace.openkit.api.OpenKitConstants;
 import com.dynatrace.openkit.protocol.Beacon;
 
+import java.net.URL;
+import java.util.regex.Pattern;
+
 /**
  * Setting the Dynatrace tag to the {@link OpenKitConstants#WEBREQUEST_TAG_HEADER} HTTP header has to be done manually by the user.
  * Inherited class of {@link WebRequestTracerBaseImpl} which can be used for tracing and timing of a web request handled by any 3rd party HTTP Client.
  */
 public class WebRequestTracerStringURL extends WebRequestTracerBaseImpl {
+
+    private static final Pattern SCHEMA_VALIDATION_PATTERN = Pattern.compile("^[a-z][a-z0-9+\\-.]*://.+", Pattern.CASE_INSENSITIVE);
 
     // *** constructors ***
 
@@ -33,9 +38,12 @@ public class WebRequestTracerStringURL extends WebRequestTracerBaseImpl {
         super(logger, beacon, action);
 
         // separate query string from URL
-        if (url != null) {
+        if (isValidURLScheme(url)) {
             this.url = url.split("\\?")[0];
         }
     }
 
+    static boolean isValidURLScheme(String url) {
+        return url != null && SCHEMA_VALIDATION_PATTERN.matcher(url).matches();
+    }
 }

--- a/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/ActionImplTest.java
@@ -518,6 +518,28 @@ public class ActionImplTest {
     }
 
     @Test
+    public void tracingAStringWebRequestWithInvalidURLIsNotAllowed() {
+
+        // given
+        final Beacon beacon = mock(Beacon.class);
+        when(beacon.getSessionNumber()).thenReturn(17);
+        final SynchronizedQueue<Action> actions = new SynchronizedQueue<Action>();
+
+        final ActionImpl target = new ActionImpl(logger, beacon, actionName, actions);
+
+        // when
+        WebRequestTracer obtained = target.traceWebRequest("foobar/://");
+
+        // then
+        assertThat(obtained, is(notNullValue()));
+        assertThat(obtained, is(instanceOf(NullWebRequestTracer.class)));
+
+        // and a warning message has been generated
+        verify(logger, times(1)).warning(
+            "ActionImpl [sn=17, id=0, name=TestAction, pa=no parent] traceWebRequest (String): url \"foobar/://\" does not have a valid scheme");
+    }
+
+    @Test
     public void tracingANullURLConnectionWebRequestIsNotAllowed() {
 
         // given

--- a/src/test/java/com/dynatrace/openkit/core/WebRequestTracerStringURLTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/WebRequestTracerStringURLTest.java
@@ -1,0 +1,74 @@
+package com.dynatrace.openkit.core;
+
+import com.dynatrace.openkit.api.Logger;
+import com.dynatrace.openkit.protocol.Beacon;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class WebRequestTracerStringURLTest {
+
+    @Test
+    public void nullIsNotAValidURLScheme() {
+
+        // then
+        assertThat(WebRequestTracerStringURL.isValidURLScheme(null), is(false));
+    }
+
+    @Test
+    public void aValidSchemeStartsWithALetter() {
+
+        // when starting with lower case letter, then
+        assertThat(WebRequestTracerStringURL.isValidURLScheme("a://some.host"), is(true));
+    }
+
+    @Test
+    public void aValidSchemeOnlyContainsLettersDigitsPlusPeriodOrHyphen() {
+
+        // when the url scheme contains all allowed characters
+        assertThat(WebRequestTracerStringURL.isValidURLScheme("b1+Z6.-://some.host"), is(true));
+    }
+
+    @Test
+    public void aValidSchemeAllowsUpperCaseLettersToo() {
+
+        // when the url scheme contains all allowed characters
+        assertThat(WebRequestTracerStringURL.isValidURLScheme("Obp1e+nZK6i.t-://some.host"), is(true));
+    }
+
+    @Test
+    public void aValidSchemeDoesNotStartWithADigit() {
+
+        assertThat(WebRequestTracerStringURL.isValidURLScheme("1a://some.host"), is(false));
+    }
+
+    @Test
+    public void aSchemeIsInvalidIfInvalidCharactersAreEncountered() {
+
+        assertThat(WebRequestTracerStringURL.isValidURLScheme("a()[]{}@://some.host"), is(false));
+    }
+
+    @Test
+    public void anURLIsOnlySetInConstructorIfItIsValid() {
+
+        // given
+        WebRequestTracerStringURL target = new WebRequestTracerStringURL(mock(Logger.class),
+            mock(Beacon.class), mock(ActionImpl.class), "a1337://foo");
+
+        // then
+        assertThat(target.getURL(), is(equalTo("a1337://foo")));
+    }
+
+    @Test
+    public void ifURLIsInvalidTheDefaultValueIsUsed() {
+        // given
+        WebRequestTracerStringURL target = new WebRequestTracerStringURL(mock(Logger.class),
+            mock(Beacon.class), mock(ActionImpl.class), "foobar");
+
+        // then
+        assertThat(target.getURL(), is(equalTo("<unknown>")));
+    }
+}

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -29,6 +29,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -444,11 +447,11 @@ public class BeaconTest {
     }
 
     @Test
-    public void canAddSentBytesToWebRequestTracer() {
+    public void canAddSentBytesToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
         int bytesSent = 12321;
@@ -458,16 +461,16 @@ public class BeaconTest {
         String[] events = beacon.getEvents();
 
         // then
-        assertThat(events, is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID
+        assertThat(events, is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID
                 + "&pa=0&s0=1&t0=0&s1=2&t1=0&bs=" + String.valueOf(bytesSent) })));
     }
 
     @Test
-    public void canAddSentBytesValueZeroToWebRequestTracer() {
+    public void canAddSentBytesValueZeroToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
         int bytesSent = 0;
@@ -477,16 +480,16 @@ public class BeaconTest {
         String[] events = beacon.getEvents();
 
         // then
-        assertThat(events, is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID
+        assertThat(events, is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID
                 + "&pa=0&s0=1&t0=0&s1=2&t1=0&bs=" + String.valueOf(bytesSent) })));
     }
 
     @Test
-    public void cannotAddSentBytesWithInvalidValueSmallerZeroToWebRequestTracer() {
+    public void cannotAddSentBytesWithInvalidValueSmallerZeroToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
 
@@ -496,15 +499,15 @@ public class BeaconTest {
 
         // then
         assertThat(events,
-                is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0" })));
+                is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0" })));
     }
 
     @Test
-    public void canAddReceivedBytesToWebRequestTracer() {
+    public void canAddReceivedBytesToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
         int bytesReceived = 12321;
@@ -514,16 +517,16 @@ public class BeaconTest {
         String[] events = beacon.getEvents();
 
         // then
-        assertThat(events, is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID
+        assertThat(events, is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID
                 + "&pa=0&s0=1&t0=0&s1=2&t1=0&br=" + String.valueOf(bytesReceived) })));
     }
 
     @Test
-    public void canAddReceivedBytesValueZeroToWebRequestTracer() {
+    public void canAddReceivedBytesValueZeroToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
         int bytesReceived = 0;
@@ -533,16 +536,16 @@ public class BeaconTest {
         String[] events = beacon.getEvents();
 
         // then
-        assertThat(events, is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID
+        assertThat(events, is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID
                 + "&pa=0&s0=1&t0=0&s1=2&t1=0&br=" + String.valueOf(bytesReceived) })));
     }
 
     @Test
-    public void cannotAddReceivedBytesWithInvalidValueSmallerZeroToWebRequestTracer() {
+    public void cannotAddReceivedBytesWithInvalidValueSmallerZeroToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
 
@@ -552,15 +555,15 @@ public class BeaconTest {
 
         // then
         assertThat(events,
-                is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0" })));
+                is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0" })));
     }
 
     @Test
-    public void canAddBothSentBytesAndReceivedBytesToWebRequestTracer() {
+    public void canAddBothSentBytesAndReceivedBytesToWebRequestTracer() throws UnsupportedEncodingException {
         // given
         Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider,
                 new NullTimeProvider());
-        String testURL = "localhost";
+        String testURL = "https://localhost";
         RootActionImpl rootAction = mock(RootActionImpl.class);
         WebRequestTracerStringURL webRequest = new WebRequestTracerStringURL(logger, beacon, rootAction, testURL);
         int bytesReceived = 12321;
@@ -572,7 +575,7 @@ public class BeaconTest {
 
         // then
         assertThat(events,
-                is(equalTo(new String[] { "et=30&na=" + testURL + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0&bs="
+                is(equalTo(new String[] { "et=30&na=" + URLEncoder.encode(testURL, "UTF-8") + "&it=" + THREAD_ID + "&pa=0&s0=1&t0=0&s1=2&t1=0&bs="
                         + String.valueOf(bytesSent) + "&br=" + String.valueOf(bytesReceived) })));
     }
 


### PR DESCRIPTION
Validate that the scheme of the given String URL to
trace conforms to RFC3986 and that it contains
at least some character after the delimiting ://