### PR TITLE
Make all OpenKit threads daemon threads

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
+++ b/src/main/java/com/dynatrace/openkit/core/BeaconSender.java
@@ -88,6 +88,7 @@ public class BeaconSender {
                 }
             }
         });
+        beaconSenderThread.setDaemon(true);
         beaconSenderThread.setName(THREAD_NAME);
         beaconSenderThread.start();
     }

--- a/src/main/java/com/dynatrace/openkit/core/caching/BeaconCacheEvictor.java
+++ b/src/main/java/com/dynatrace/openkit/core/caching/BeaconCacheEvictor.java
@@ -58,6 +58,7 @@ public class BeaconCacheEvictor {
     BeaconCacheEvictor(Logger logger, BeaconCache beaconCache, BeaconCacheEvictionStrategy... strategies) {
         this.logger = logger;
         evictionThread = new Thread(new CacheEvictionRunnable(logger, beaconCache, strategies), THREAD_NAME);
+        evictionThread.setDaemon(true);
     }
 
     /**


### PR DESCRIPTION
All OpenKit threads must be daemon threads. If the
client application does not properly shut down OpenKit
and threads are non-daemon threads, then OpenKit would
block the client application.