### PR TITLE
Fix wrong session start time

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
+++ b/src/main/java/com/dynatrace/openkit/core/SessionImpl.java
@@ -54,7 +54,7 @@ public class SessionImpl implements Session {
         this.beacon = beacon;
 
         beaconSender.startSession(this);
-        beacon.startSession(this);
+        beacon.startSession();
     }
 
     // *** Session interface methods ***

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -275,7 +275,7 @@ public class Beacon {
         addActionData(action.getStartTime(), actionBuilder);
     }
 
-    public void startSession(SessionImpl session) {
+    public void startSession() {
 
         if (isCapturingDisabled()) {
             return;

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -287,9 +287,9 @@ public class Beacon {
 
         addKeyValuePair(eventBuilder, BEACON_KEY_PARENT_ACTION_ID, 0);
         addKeyValuePair(eventBuilder, BEACON_KEY_START_SEQUENCE_NUMBER, createSequenceNumber());
-        addKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, getTimeSinceSessionStartTime(session.getEndTime()));
+        addKeyValuePair(eventBuilder, BEACON_KEY_TIME_0, 0L);
 
-        addEventData(session.getEndTime(), eventBuilder);
+        addEventData(sessionStartTime, eventBuilder);
     }
 
     /**

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -275,6 +275,13 @@ public class Beacon {
         addActionData(action.getStartTime(), actionBuilder);
     }
 
+    /**
+     * Add start session event to Beacon.
+     *
+     * <p>
+     * The serialized data is added to {@link com.dynatrace.openkit.core.caching.BeaconCache}.
+     * </p>
+     */
     public void startSession() {
 
         if (isCapturingDisabled()) {

--- a/src/test/java/com/dynatrace/openkit/core/SessionImplTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/SessionImplTest.java
@@ -182,7 +182,7 @@ public class SessionImplTest {
         // verify the correct methods being called
         verify(logger, times(1)).warning("SessionImpl [sn=0] identifyUser: userTag must not be null or empty");
         verify(beacon, times(1)).getSessionNumber();
-        verify(beacon, times(1)).startSession(session);
+        verify(beacon, times(1)).startSession();
         verify(beacon, times(0)).identifyUser(anyString());
         verifyNoMoreInteractions(beacon);
     }
@@ -198,7 +198,7 @@ public class SessionImplTest {
 
         // verify the correct methods being called
         verify(logger, times(1)).warning("SessionImpl [sn=0] identifyUser: userTag must not be null or empty");
-        verify(beacon, times(1)).startSession(session);
+        verify(beacon, times(1)).startSession();
         verify(beacon, times(1)).getSessionNumber();
         verify(beacon, times(0)).identifyUser(anyString());
         verifyNoMoreInteractions(beacon);
@@ -268,7 +268,7 @@ public class SessionImplTest {
         // verify the correct methods being called
         verify(logger, times(1)).warning("SessionImpl [sn=0] reportCrash: errorName must not be null or empty");
         verify(beacon, times(1)).getSessionNumber();
-        verify(beacon, times(1)).startSession(session);
+        verify(beacon, times(1)).startSession();
         verifyZeroInteractions(beacon, beacon);
     }
 
@@ -284,7 +284,7 @@ public class SessionImplTest {
         // verify the correct methods being called
         verify(logger, times(1)).warning("SessionImpl [sn=0] reportCrash: errorName must not be null or empty");
         verify(beacon, times(1)).getSessionNumber();
-        verify(beacon, times(1)).startSession(session);
+        verify(beacon, times(1)).startSession();
         verifyZeroInteractions(beacon, beacon);
     }
 

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -1554,14 +1554,12 @@ public class BeaconTest {
     public void sessionStartIsReported() {
         // given
         Beacon target = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
-        SessionImpl sessionMock = mock(SessionImpl.class);
 
         // when
-        target.startSession(sessionMock);
+        target.startSession();
 
         // then ensure session start has been serialized
         assertThat(target.isEmpty(), is(false));
-        verify(sessionMock, times(2)).getEndTime();
     }
 
     @Test
@@ -1569,14 +1567,12 @@ public class BeaconTest {
         // given
         Beacon target = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
         target.setBeaconConfiguration(new BeaconConfiguration(1, DataCollectionLevel.OFF, CrashReportingLevel.OPT_IN_CRASHES));
-        SessionImpl sessionMock = mock(SessionImpl.class);
 
         // when
-        target.startSession(sessionMock);
+        target.startSession();
 
         // then ensure session start has been serialized
         assertThat(target.isEmpty(), is(false));
-        verify(sessionMock, times(2)).getEndTime();
     }
 
     @Test
@@ -1584,14 +1580,12 @@ public class BeaconTest {
         // given
         Beacon target = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
         target.setBeaconConfiguration(new BeaconConfiguration(1, DataCollectionLevel.PERFORMANCE, CrashReportingLevel.OPT_IN_CRASHES));
-        SessionImpl sessionMock = mock(SessionImpl.class);
 
         // when
-        target.startSession(sessionMock);
+        target.startSession();
 
         // then ensure session start has been serialized
         assertThat(target.isEmpty(), is(false));
-        verify(sessionMock, times(2)).getEndTime();
     }
 
     @Test
@@ -1599,14 +1593,12 @@ public class BeaconTest {
         // given
         Beacon target = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
         target.setBeaconConfiguration(new BeaconConfiguration(1, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES));
-        SessionImpl sessionMock = mock(SessionImpl.class);
 
         // when
-        target.startSession(sessionMock);
+        target.startSession();
 
         // then ensure session start has been serialized
         assertThat(target.isEmpty(), is(false));
-        verify(sessionMock, times(2)).getEndTime();
     }
 
     @Test
@@ -1614,13 +1606,11 @@ public class BeaconTest {
         // given
         Beacon target = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
         target.setBeaconConfiguration(new BeaconConfiguration(0, DataCollectionLevel.USER_BEHAVIOR, CrashReportingLevel.OPT_IN_CRASHES));
-        SessionImpl sessionMock = mock(SessionImpl.class);
 
         // when
-        target.startSession(sessionMock);
+        target.startSession();
 
         // then ensure nothing has been serialized
         assertThat(target.isEmpty(), is(true));
-        verifyZeroInteractions(sessionMock);
     }
 }


### PR DESCRIPTION
When reporting the Session start time the OpenKit code
used the session end time, which was incorrect.
Based on the protocol description this should be 0L.