### PR TITLE
Null SSL Trust Manager can no longer be set.

### DIFF
--- a/src/main/java/com/dynatrace/openkit/AbstractOpenKitBuilder.java
+++ b/src/main/java/com/dynatrace/openkit/AbstractOpenKitBuilder.java
@@ -101,13 +101,15 @@ public abstract class AbstractOpenKitBuilder {
     }
 
     /**
-     * Sets the trust manager. Overrides the default trust manager which is {@code SSLStrictTrustmanager} by default-
+     * Sets the trust manager if it's not {@code null}, overriding the default{@link SSLStrictTrustManager}.
      *
      * @param trustManager trust manager implementation
      * @return {@code this}
      */
     public AbstractOpenKitBuilder withTrustManager(SSLTrustManager trustManager) {
-        this.trustManager = trustManager;
+        if (trustManager != null) {
+            this.trustManager = trustManager;
+        }
         return this;
     }
 

--- a/src/test/java/com/dynatrace/openkit/OpenKitBuilderTest.java
+++ b/src/test/java/com/dynatrace/openkit/OpenKitBuilderTest.java
@@ -94,6 +94,16 @@ public class OpenKitBuilderTest {
     }
 
     @Test
+    public void cannotSetANullTrustManagerForAppMon() {
+
+        Configuration target = new AppMonOpenKitBuilder(ENDPOINT, APP_NAME, DEVICE_ID)
+            .withTrustManager(null)
+            .buildConfiguration();
+
+        assertThat(target.getHttpClientConfig().getSSLTrustManager(), is(instanceOf(SSLStrictTrustManager.class)));
+    }
+
+    @Test
     public void canOverrideTrustManagerForDynatrace() {
         SSLTrustManager trustManager = mock(SSLTrustManager.class);
 
@@ -102,6 +112,16 @@ public class OpenKitBuilderTest {
             .buildConfiguration();
 
         assertThat(target.getHttpClientConfig().getSSLTrustManager(), is(sameInstance(trustManager)));
+    }
+
+    @Test
+    public void cannotSetANullTrustManagerForDynatrace() {
+
+        Configuration target = new DynatraceOpenKitBuilder(ENDPOINT, APP_ID, DEVICE_ID)
+            .withTrustManager(null)
+            .buildConfiguration();
+
+        assertThat(target.getHttpClientConfig().getSSLTrustManager(), is(instanceOf(SSLStrictTrustManager.class)));
     }
 
     @Test


### PR DESCRIPTION
This is the same for OpenKit .NET