### PR TITLE
Version handling in OpenKit Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ group 'com.dynatrace.openkit'
 version '1.2.0-SNAPSHOT'
 
 def groupString = group
+def title = 'Dynatrace OpenKit SDK for Java'
+def vendor = 'Dynatrace LLC'
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'
@@ -51,8 +53,6 @@ jar {
         classifier = 'java' + target
     }
 
-    def vendor = 'Dynatrace LLC'
-
     // split version into specification & implementation version
     def specVersion = version
     def implVersion = ''
@@ -72,7 +72,7 @@ jar {
 
     manifest {
         attributes 'Name': "${name}/",
-                'Specification-Title': 'Dynatrace OpenKit SDK for Java',
+                'Specification-Title': title,
                 'Specification-Version': specVersion,
                 'Specification-Vendor': vendor,
                 'Implementation-Title': groupString,

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,20 @@
 buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
-  }
-  dependencies {
-    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
-    classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
-    classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
-  }
+    dependencies {
+        classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.11.0'
+        classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+    }
 }
 
 group 'com.dynatrace.openkit'
 version '1.2.0-SNAPSHOT'
 
-def buildNumber = System.getenv()['BUILD_NUMBER']
-if (version.endsWith('-SNAPSHOT') && buildNumber != null) {
-  version version + '-' + buildNumber
-}
+def groupString = group
 
 apply plugin: 'java'
 apply plugin: 'maven-publish'
@@ -54,11 +51,34 @@ jar {
         classifier = 'java' + target
     }
 
+    def vendor = 'Dynatrace LLC'
+
+    // split version into specification & implementation version
+    def specVersion = version
+    def implVersion = ''
+    def splitIndex = version.indexOf('-')
+    if (splitIndex != -1) {
+        implVersion = version.substring(splitIndex + 1)
+        specVersion = version.take(splitIndex)
+    }
+
+    // append build information to the spec version
+    def buildNumber = System.getenv()['BUILD_NUMBER']
+    if (buildNumber != null) {
+        implVersion = "${implVersion}-b${buildNumber}"
+    }
+
+    def name = groupString.replaceAll('\\.', '/')
+
     manifest {
-      attributes 'Specification-Title': 'Dynatrace OpenKit SDK for Java',
-				'Specification-Version': version,
-				'Specification-Vendor': 'Dynatrace LLC',
-				'url': 'https://github.com/Dynatrace/openkit-java'
+        attributes 'Name': "${name}/",
+                'Specification-Title': 'Dynatrace OpenKit SDK for Java',
+                'Specification-Version': specVersion,
+                'Specification-Vendor': vendor,
+                'Implementation-Title': groupString,
+                'Implementation-Version': implVersion,
+                'Implementation-Vendor': vendor,
+                'url': 'https://github.com/Dynatrace/openkit-java'
     }
 }
 
@@ -101,8 +121,8 @@ task javadocZip(type: Zip, dependsOn: javadoc) {
 }
 
 task javadocJar(type: Jar) {
-	classifier = 'javadoc'
-	from javadoc
+    classifier = 'javadoc'
+    from javadoc
 }
 
 artifacts {
@@ -110,24 +130,29 @@ artifacts {
 }
 
 publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			artifactId project.name
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId project.name
 
-			from components.java
+            from components.java
 
-			artifact sourceJar {
-				classifier "sources"
-			}
-			artifact javadocJar {
-				classifier "javadoc"
-			}
-		}
-	}
+            artifact sourceJar {
+                classifier "sources"
+            }
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+        }
+    }
 }
 
 task printVersion {
-  doLast {
-    logger.quiet version
-  }
+    doLast {
+        def buildNumber = System.getenv()['BUILD_NUMBER']
+        if (buildNumber != null) {
+            logger.quiet "${version}-b${buildNumber}"
+        } else {
+            logger.quiet version
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ def target = System.getenv("TARGET_COMPATIBILITY") ?: "6"
 sourceCompatibility = 1.6
 targetCompatibility = "1." + target
 
-
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
+++ b/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
@@ -16,6 +16,10 @@
 
 package com.dynatrace.openkit.api;
 
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
 /**
  * Defines constant values used in OpenKit
  */
@@ -35,9 +39,37 @@ public class OpenKitConstants {
     public static final String WEBREQUEST_TAG_HEADER = "X-dynaTrace";
 
     // default values used in configuration
-    public static final String DEFAULT_APPLICATION_VERSION = "1.2.0";
-    public static final String DEFAULT_OPERATING_SYSTEM = "OpenKit " + DEFAULT_APPLICATION_VERSION;
-    public static final String DEFAULT_MANUFACTURER = "Dynatrace";
+    public static final String DEFAULT_APPLICATION_VERSION;
+    public static final String DEFAULT_OPERATING_SYSTEM;
+    public static final String DEFAULT_MANUFACTURER;
     public static final String DEFAULT_MODEL_ID = "OpenKitDevice";
 
+    // load default version and vendor information from MANIFEST.MF
+    static {
+
+        String specificationVersion = "<unknown version>";
+        String implementationVersion = "<unknown version>";
+        String implementationVendor = "Dynatrace";
+
+        try {
+            Class clazz = OpenKitConstants.class;
+            String className = clazz.getSimpleName() + ".class";
+            String classPath = clazz.getResource(className).toString();
+            if (classPath.startsWith("jar")) {
+                String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
+                Manifest manifest = new Manifest(new URL(manifestPath).openStream());
+                Attributes attr = manifest.getMainAttributes();
+
+                specificationVersion = attr.getValue("Specification-Version");
+                implementationVersion = attr.getValue("Implementation-Version");
+                implementationVendor = attr.getValue("Implementation-Vendor");
+            }
+        } catch (Exception e) {
+            // intentionally left empty
+        }
+
+        DEFAULT_APPLICATION_VERSION = specificationVersion + "-" + implementationVersion;
+        DEFAULT_OPERATING_SYSTEM = "OpenKit " + DEFAULT_APPLICATION_VERSION;
+        DEFAULT_MANUFACTURER = implementationVendor;
+    }
 }


### PR DESCRIPTION
Versions + Vendor is taken from MANIFEST.MF.
The generated MANIFEST.MF sticks to the guidelines defined by Oracle (https://docs.oracle.com/javase/tutorial/deployment/jar/packageman.html).