### PR TITLE
Fix wrong pattern for SimpleDateFormat

### DIFF
--- a/src/main/java/com/dynatrace/openkit/api/Logger.java
+++ b/src/main/java/com/dynatrace/openkit/api/Logger.java
@@ -61,28 +61,28 @@ public interface Logger {
     /**
      * Return a flag if 'error' level messages are currently printed
      *
-     * @return true if 'error' level messages are printed, 'false' if not
+     * @return {@code true} if 'error' level messages are printed, {@code false} if not
      */
     boolean isErrorEnabled();
 
     /**
      * Return a flag if 'warn' level messages are currently printed
      *
-     * @return true if 'warn' level messages are printed, 'false' if not
+     * @return {@code true} if 'warn' level messages are printed, {@code false} if not
      */
     boolean isWarnEnabled();
 
     /**
      * Return a flag if 'info' level messages are currently printed
      *
-     * @return true if 'info' level messages are printed, 'false' if not
+     * @return {@code true} if 'info' level messages are printed, {@code false} if not
      */
     boolean isInfoEnabled();
 
     /**
      * Return a flag if 'debug' level messages are currently printed
      *
-     * @return true if 'debug' level messages are printed, 'false' if not
+     * @return {@code true} if 'debug' level messages are printed, {@code false} if not
      */
     boolean isDebugEnabled();
 

--- a/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
+++ b/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
@@ -30,7 +30,7 @@ public class DefaultLogger implements Logger {
     private final boolean verbose;
     private final PrintStream outputStream;
 
-    static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     static {
         DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
+++ b/src/main/java/com/dynatrace/openkit/core/util/DefaultLogger.java
@@ -18,6 +18,7 @@ package com.dynatrace.openkit.core.util;
 
 import com.dynatrace.openkit.api.Logger;
 
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
@@ -26,26 +27,31 @@ import java.util.TimeZone;
 
 public class DefaultLogger implements Logger {
 
-    private boolean verbose;
+    private final boolean verbose;
+    private final PrintStream outputStream;
 
-    static final String DATEFORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
-    static final SimpleDateFormat dateFormat = new SimpleDateFormat(DATEFORMAT);
+    static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     static {
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     private static String getUTCTime() {
-        return dateFormat.format(new Date());
+        return DATE_FORMAT.format(new Date());
     }
 
     public DefaultLogger(boolean verbose) {
+        this(verbose, System.out);
+    }
+
+    DefaultLogger(boolean verbose, PrintStream outputStream) {
         this.verbose = verbose;
+        this.outputStream = outputStream;
     }
 
     @Override
     public void error(String message) {
-        System.out.println(getUTCTime() + " [ERROR] " + message);
+        outputStream.println(getUTCTime() + " [ERROR] " + message);
     }
 
     @Override
@@ -55,25 +61,25 @@ public class DefaultLogger implements Logger {
         t.printStackTrace(printWriter);
         final String stacktrace = stringWriter.getBuffer().toString();
 
-        System.out.println(getUTCTime() + " [ERROR] " + message + System.getProperty("line.separator") + stacktrace);
+        outputStream.println(getUTCTime() + " [ERROR] " + message + System.getProperty("line.separator") + stacktrace);
     }
 
     @Override
     public void warning(String message) {
-        System.out.println(getUTCTime() + " [WARN ] " + message);
+        outputStream.println(getUTCTime() + " [WARN ] " + message);
     }
 
     @Override
     public void info(String message) {
         if (isInfoEnabled()) {
-            System.out.println(getUTCTime() + " [INFO ] " + message);
+            outputStream.println(getUTCTime() + " [INFO ] " + message);
         }
     }
 
     @Override
     public void debug(String message) {
         if (isDebugEnabled()) {
-            System.out.println(getUTCTime() + " [DEBUG] " + message);
+            outputStream.println(getUTCTime() + " [DEBUG] " + message);
         }
     }
 

--- a/src/test/java/com/dynatrace/openkit/core/util/DefaultLoggerTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/util/DefaultLoggerTest.java
@@ -16,83 +16,209 @@
 
 package com.dynatrace.openkit.core.util;
 
-import com.dynatrace.openkit.core.util.DefaultLogger;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import java.io.*;
+import java.util.regex.Pattern;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isEmptyString;
 
 public class DefaultLoggerTest {
+
+    private static final String CHARSET = "UTF-8";
+
+    private ByteArrayOutputStream byteArrayOutputStream;
+    private PrintStream printStream;
+
+    @Before
+    public void setUp() throws UnsupportedEncodingException {
+        byteArrayOutputStream = new ByteArrayOutputStream();
+        printStream = new PrintStream(byteArrayOutputStream, true, CHARSET);
+    }
+
+    @After
+    public void tearDown() {
+        printStream.close();
+    }
 
     @Test
     public void defaultLoggerWithVerboseOutputWritesErrorLevelMessages() {
         //given
-        DefaultLogger log = new DefaultLogger(true);
+        DefaultLogger target = new DefaultLogger(true);
 
         //then
-        assertThat(log.isErrorEnabled(), is(true));
+        assertThat(target.isErrorEnabled(), is(true));
     }
 
     @Test
-    public void defaultLoggerWithVerboseOutputWritesWarnLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(true);
+    public void errorLogsAppropriateMessage() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isWarnEnabled(), is(true));
+        //given
+        DefaultLogger target = new DefaultLogger(true, printStream);
+
+        // when
+        target.error("Error message");
+        String obtained = byteArrayOutputStream.toString(CHARSET).trim();
+
+        // then
+        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[ERROR] Error message$", obtained),
+            is(true));
     }
 
     @Test
-    public void defaultLoggerWithVerboseOutputWritesInfoLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(true);
+    public void errorWithStacktraceLogsAppropriateMessage() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isInfoEnabled(), is(true));
+        //given
+        Exception e = new Exception("test exception");
+        DefaultLogger target = new DefaultLogger(true, printStream);
+
+        // when
+        target.error("Error message", e);
+        String[] obtained = byteArrayOutputStream.toString(CHARSET).trim().split(System.getProperty("line.separator"), 2);
+
+        // then
+        assertThat(obtained.length, is(equalTo(2)));
+        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[ERROR] Error message$", obtained[0]),
+            is(true));
+
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter, true);
+        e.printStackTrace(printWriter);
+        final String expectedStacktrace = stringWriter.getBuffer().toString().trim();
+        assertThat(obtained[1], is(equalTo(expectedStacktrace)));
     }
 
     @Test
-    public void defaultLoggerWithVerboseOutputWritesDebugLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(true);
+    public void warningLogsAppropriateMessage() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isDebugEnabled(), is(true));
+        //given
+        DefaultLogger target = new DefaultLogger(true, printStream);
+
+        // when
+        target.warning("Warning message");
+        String obtained = byteArrayOutputStream.toString(CHARSET).trim();
+
+        // then
+        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[WARN ] Warning message$", obtained),
+            is(true));
     }
 
     @Test
-    public void defaultLoggerWithoutVerboseOutputWritesErrorLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(false);
+    public void infoLogsAppropriateMessage() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isErrorEnabled(), is(true));
+        //given
+        DefaultLogger target = new DefaultLogger(true, printStream);
+
+        // when
+        target.info("Info message");
+        String obtained = byteArrayOutputStream.toString(CHARSET).trim();
+
+        // then
+        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[INFO ] Info message$", obtained),
+            is(true));
     }
 
     @Test
-    public void defaultLoggerWithoutVerboseOutputWritesWarnLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(false);
+    public void infoDoesNotLogIfVerboseIsDisabled() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isWarnEnabled(), is(true));
+        //given
+        DefaultLogger target = new DefaultLogger(false, printStream);
+
+        // when
+        target.info("Info message");
+        String obtained = byteArrayOutputStream.toString(CHARSET);
+
+        // then
+        assertThat(obtained, isEmptyString());
     }
 
     @Test
-    public void defaultLoggerWithoutVerboseOutputWritesInfoLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(false);
+    public void debugLogsAppropriateMessage() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isInfoEnabled(), is(false));
+        //given
+        DefaultLogger target = new DefaultLogger(true, printStream);
+
+        // when
+        target.debug("Debug message");
+        String obtained = byteArrayOutputStream.toString(CHARSET).trim();
+
+        // then
+        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[DEBUG] Debug message$", obtained),
+            is(true));
     }
 
     @Test
-    public void defaultLoggerWithoutVerboseOutputWritesDebugLevelMessages() {
-        //given
-        DefaultLogger log = new DefaultLogger(false);
+    public void debugDoesNotLogIfVerboseIsDisabled() throws UnsupportedEncodingException {
 
-        //then
-        assertThat(log.isDebugEnabled(), is(false));
+        //given
+        DefaultLogger target = new DefaultLogger(false, printStream);
+
+        // when
+        target.debug("Debug message");
+        String obtained = byteArrayOutputStream.toString(CHARSET);
+
+        // then
+        assertThat(obtained, isEmptyString());
+    }
+
+    @Test
+    public void isErrorEnabledIsTrueIfVerboseIsTrue() {
+
+        // then
+        assertThat(new DefaultLogger(true).isErrorEnabled(), is(true));
+    }
+
+    @Test
+    public void isErrorEnabledIsTrueIfVerboseIsFalse() {
+
+        // then
+        assertThat(new DefaultLogger(false).isErrorEnabled(), is(true));
+    }
+
+    @Test
+    public void isWarnEnabledIsTrueIfVerboseIsTrue() {
+
+        // then
+        assertThat(new DefaultLogger(true).isWarnEnabled(), is(true));
+    }
+
+    @Test
+    public void isWarnEnabledIsTrueIfVerboseIsFalse() {
+
+        // then
+        assertThat(new DefaultLogger(false).isWarnEnabled(), is(true));
+    }
+
+    @Test
+    public void isInfoEnabledIsTrueIfVerboseIsTrue() {
+
+        // then
+        assertThat(new DefaultLogger(true).isInfoEnabled(), is(true));
+    }
+
+    @Test
+    public void isInfoEnabledIsFalseIfVerboseIsFalse() {
+
+        // then
+        assertThat(new DefaultLogger(false).isInfoEnabled(), is(false));
+    }
+
+    @Test
+    public void isDebugEnabledIsTrueIfVerboseIsTrue() {
+
+        // then
+        assertThat(new DefaultLogger(true).isDebugEnabled(), is(true));
+    }
+
+    @Test
+    public void isDebugEnabledIsFalseIfVerboseIsFalse() {
+
+        // then
+        assertThat(new DefaultLogger(false).isDebugEnabled(), is(false));
     }
 }

--- a/src/test/java/com/dynatrace/openkit/core/util/DefaultLoggerTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/util/DefaultLoggerTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.isEmptyString;
 public class DefaultLoggerTest {
 
     private static final String CHARSET = "UTF-8";
+    private static final String LOGGER_DATE_TIME_PATTERN = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}";
 
     private ByteArrayOutputStream byteArrayOutputStream;
     private PrintStream printStream;
@@ -66,7 +67,7 @@ public class DefaultLoggerTest {
         String obtained = byteArrayOutputStream.toString(CHARSET).trim();
 
         // then
-        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[ERROR] Error message$", obtained),
+        assertThat(Pattern.matches("^" + LOGGER_DATE_TIME_PATTERN + " \\[ERROR] Error message$", obtained),
             is(true));
     }
 
@@ -83,7 +84,7 @@ public class DefaultLoggerTest {
 
         // then
         assertThat(obtained.length, is(equalTo(2)));
-        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[ERROR] Error message$", obtained[0]),
+        assertThat(Pattern.matches("^" + LOGGER_DATE_TIME_PATTERN + " \\[ERROR] Error message$", obtained[0]),
             is(true));
 
         final StringWriter stringWriter = new StringWriter();
@@ -104,7 +105,7 @@ public class DefaultLoggerTest {
         String obtained = byteArrayOutputStream.toString(CHARSET).trim();
 
         // then
-        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[WARN ] Warning message$", obtained),
+        assertThat(Pattern.matches("^" + LOGGER_DATE_TIME_PATTERN + " \\[WARN ] Warning message$", obtained),
             is(true));
     }
 
@@ -119,7 +120,7 @@ public class DefaultLoggerTest {
         String obtained = byteArrayOutputStream.toString(CHARSET).trim();
 
         // then
-        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[INFO ] Info message$", obtained),
+        assertThat(Pattern.matches("^" + LOGGER_DATE_TIME_PATTERN + " \\[INFO ] Info message$", obtained),
             is(true));
     }
 
@@ -148,7 +149,7 @@ public class DefaultLoggerTest {
         String obtained = byteArrayOutputStream.toString(CHARSET).trim();
 
         // then
-        assertThat(Pattern.matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3} \\[DEBUG] Debug message$", obtained),
+        assertThat(Pattern.matches("^" + LOGGER_DATE_TIME_PATTERN + " \\[DEBUG] Debug message$", obtained),
             is(true));
     }
 


### PR DESCRIPTION
In Java 6 the pattern string X is unknown for SimpleDateFormat.
This would just add the timezone in ISO-8601 format to the string.
Due to the fact that the DefaultLogger uses UTC timezone, this does
not add useful information in the string. Therefore it's removed.

Also did refactor the tests and some documentation.