### PR TITLE
Wrong device ID was in use for data collection level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Fix wrong Session start time
 - Fix wrong SimpleDatePattern, which does not work with Java 6
+- Fix wrong device ID in web requests
 
 ### Improved
 - OpenKit internal version handling

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -108,6 +108,9 @@ public class Beacon {
     private final ThreadIDProvider threadIDProvider;
     private final long sessionStartTime;
 
+    // unique device identifier
+    private final long deviceID;
+
     // client IP address
     private final String clientIPAddress;
 
@@ -165,6 +168,8 @@ public class Beacon {
         this.threadIDProvider = threadIDProvider;
         this.sessionStartTime = timingProvider.provideTimestampInMilliseconds();
 
+        this.deviceID = createDeviceID(random, configuration);
+
         this.random = random;
 
         if (InetAddressValidator.isValidIP(clientIPAddress)) {
@@ -182,6 +187,39 @@ public class Beacon {
         beaconConfiguration = new AtomicReference<BeaconConfiguration>(configuration.getBeaconConfiguration());
 
         immutableBasicBeaconData = createImmutableBasicBeaconData();
+    }
+
+    /**
+     * Create a device ID.
+     *
+     * @param random Pseudo random number generator.
+     * @param configuration Configuration.
+     * @return A device ID, which might either be the one set when building OpenKit or a randomly generated one.
+     */
+    private static long createDeviceID(Random random, Configuration configuration) {
+
+        if (configuration == null) {
+            return nextRandomPositiveLong(random);
+        }
+
+        BeaconConfiguration beaconConfig = configuration.getBeaconConfiguration();
+        if (beaconConfig != null && beaconConfig.getDataCollectionLevel() == DataCollectionLevel.USER_BEHAVIOR) {
+            // configuration is valid and user allows data tracking
+            return configuration.getDeviceID();
+        }
+
+        // no user tracking allowed
+        return nextRandomPositiveLong(random);
+    }
+
+    /**
+     * Get a random long, which is in positive range (including {@code 0}).
+     *
+     * @param random Pseudo random number generator.
+     * @return Randomly generated long, which is greater than or equal to {@code 0}.
+     */
+    private static long nextRandomPositiveLong(Random random) {
+        return random.nextLong() & 0x7fffffffffffffffL;
     }
 
     /**
@@ -237,8 +275,8 @@ public class Beacon {
         if (getBeaconConfiguration().getDataCollectionLevel() == DataCollectionLevel.OFF) {
             return "";
         }
-        return TAG_PREFIX + "_" + ProtocolConstants.PROTOCOL_VERSION + "_" + httpConfiguration.getServerID() + "_" + configuration
-            .getDeviceID() + "_" + sessionNumber + "_" + configuration.getApplicationID() + "_" + parentAction.getID() + "_" + threadIDProvider
+        return TAG_PREFIX + "_" + ProtocolConstants.PROTOCOL_VERSION + "_" + httpConfiguration.getServerID() + "_" + getDeviceID()
+            + "_" + sessionNumber + "_" + configuration.getApplicationID() + "_" + parentAction.getID() + "_" + threadIDProvider
             .getThreadID() + "_" + sequenceNo;
     }
 
@@ -798,17 +836,10 @@ public class Beacon {
      * in case of level 2 (USER_BEHAVIOR) the value from the configuration is used
      * in case of level 1 (PERFORMANCE) or 0 (OFF) a random number in the positive Long range is used
      *
-     * @return
+     * @return Unique device identifier.
      */
     public long getDeviceID() {
-        BeaconConfiguration beaconConfig = getBeaconConfiguration();
-        if (configuration != null && beaconConfig != null) {
-            DataCollectionLevel dataCollectionLevel = beaconConfig.getDataCollectionLevel();
-            if (dataCollectionLevel == DataCollectionLevel.USER_BEHAVIOR) {
-                return configuration.getDeviceID();
-            }
-        }
-        return random.nextLong() & 0x7fffffffffffffffL; // ensure a positive long
+        return deviceID;
     }
 
     /**
@@ -817,7 +848,7 @@ public class Beacon {
      * in case of level 2 ({@link DataCollectionLevel#USER_BEHAVIOR}) the value from the session id provider is used
      * in case of level 1 ({@link DataCollectionLevel#PERFORMANCE}) or 0 ({@link DataCollectionLevel#OFF}) a random positive int value is used
      *
-     * @return
+     * @return Pre calculated session number or {@code 1} if data collection level is not equal to {@link DataCollectionLevel#USER_BEHAVIOR}.
      */
     public int getSessionNumber() {
         DataCollectionLevel dataCollectionLevel = getBeaconConfiguration().getDataCollectionLevel();

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -1023,7 +1023,7 @@ public class BeaconTest {
         // then verify that the device id is not taken from the configuration
         // this means it must have been generated randomly
         verify(mockConfiguration, times(0)).getDeviceID();
-        verify(mockRandom, times(2)).nextLong();
+        verify(mockRandom, times(1)).nextLong();
     }
 
     @Test
@@ -1046,7 +1046,7 @@ public class BeaconTest {
         // then verify that the device id is not taken from the configuration
         // this means it must have been generated randomly
         verify(mockConfiguration, times(0)).getDeviceID();
-        verify(mockRandom, times(2)).nextLong();
+        verify(mockRandom, times(1)).nextLong();
     }
 
     @Test
@@ -1069,7 +1069,7 @@ public class BeaconTest {
         long visitorID = target.getDeviceID();
 
         //then verify that device id is taken from configuration
-        verify(mockConfiguration, times(2)).getDeviceID();
+        verify(mockConfiguration, times(1)).getDeviceID();
         verifyNoMoreInteractions(mockRandom);
         assertThat(visitorID, is(equalTo(TEST_DEVICE_ID)));
     }
@@ -1094,9 +1094,10 @@ public class BeaconTest {
         //when
         long visitorID = target.getDeviceID();
 
-        //then verify that device id is taken from configuration
-        verify(mockRandom, times(2)).nextLong();
-        assertThat(visitorID, is(greaterThanOrEqualTo(1L)));
+        //then verify that the id is positive regardless of the data collection level
+        verify(mockRandom, times(1)).nextLong();
+        assertThat(visitorID, is(greaterThanOrEqualTo(0L)));
+        assertThat(visitorID, is(equalTo(-123456789L & Long.MAX_VALUE)));
     }
 
     @Test
@@ -1119,9 +1120,10 @@ public class BeaconTest {
         //when
         long visitorID = target.getDeviceID();
 
-        //then verify that the id is positive regardless of the
-        verify(mockRandom, times(2)).nextLong();
-        assertThat(visitorID, is(greaterThanOrEqualTo(1L)));
+        //then verify that the id is positive regardless of the data collection level
+        verify(mockRandom, times(1)).nextLong();
+        assertThat(visitorID, is(greaterThanOrEqualTo(0L)));
+        assertThat(visitorID, is(equalTo(-123456789L & Long.MAX_VALUE)));
     }
 
     @Test


### PR DESCRIPTION
This is a cherry pick from the fix in release/1.1 branch.