### PR TITLE
Take Travis CI build number into account

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,24 @@ jar {
     }
 
     // append build information to the spec version
-    def buildNumber = System.getenv()['BUILD_NUMBER']
+    def buildNumber
+    if (System.getenv('TRAVIS') != null) {
+        // if the build is running on Travis CI, then the
+        // build number can be retrieved via TRAVIS_BUILD_NUMBER
+        buildNumber = System.getenv('TRAVIS_BUILD_NUMBER')
+    } else {
+        // otherwise via BUILD_NUMBER
+        buildNumber = System.getenv('BUILD_NUMBER')
+    }
+
     if (buildNumber != null) {
-        implVersion = "${implVersion}-b${buildNumber}"
+        if (implVersion?.trim()) {
+            // SNAPSHOT release or release candidate
+            implVersion = "${implVersion}-b${buildNumber}"
+        } else {
+            // release
+            implVersion = "b${buildNumber}"
+        }
     }
 
     def name = groupString.replaceAll('\\.', '/')

--- a/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
+++ b/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
@@ -68,7 +68,11 @@ public class OpenKitConstants {
             // intentionally left empty
         }
 
-        DEFAULT_APPLICATION_VERSION = specificationVersion + "-" + implementationVersion;
+        if (implementationVersion != null && !implementationVersion.trim().isEmpty()) {
+            DEFAULT_APPLICATION_VERSION = specificationVersion + "-" + implementationVersion;
+        } else {
+            DEFAULT_APPLICATION_VERSION = specificationVersion;
+        }
         DEFAULT_OPERATING_SYSTEM = "OpenKit " + DEFAULT_APPLICATION_VERSION;
         DEFAULT_MANUFACTURER = implementationVendor;
     }


### PR DESCRIPTION
When building on Travis CI, TRAVIS_BUILD_NUMBER
has to be used to determine the build number.

Furthermore, do not append a hypen ('-') and nothing
else, if Implementation-Version is not set.