### PR TITLE
URL Encode ApplicationID/DeviceID

### DIFF
--- a/src/main/java/com/dynatrace/openkit/core/configuration/Configuration.java
+++ b/src/main/java/com/dynatrace/openkit/core/configuration/Configuration.java
@@ -18,6 +18,7 @@ package com.dynatrace.openkit.core.configuration;
 
 import com.dynatrace.openkit.api.SSLTrustManager;
 import com.dynatrace.openkit.core.Device;
+import com.dynatrace.openkit.core.util.PercentEncoder;
 import com.dynatrace.openkit.protocol.Response;
 import com.dynatrace.openkit.protocol.StatusResponse;
 import com.dynatrace.openkit.providers.SessionIDProvider;
@@ -29,6 +30,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class Configuration {
 
+    /** Character set used to encode application & device ID */
+    private static final String ENCODING_CHARSET = "UTF-8";
+    /** Underscore is a reserved character in the server, therefore it also needs to be encoded */
+    private static final char[] RESERVED_CHARACTERS = {'_'};
+
     private static final boolean DEFAULT_CAPTURE = true;                           // default: capture on
     private static final int DEFAULT_SEND_INTERVAL = 2 * 60 * 1000;                 // default: wait 2m (in ms) to send beacon
     private static final int DEFAULT_MAX_BEACON_SIZE = 30 * 1024;                   // default: max 30KB (in B) to send in one beacon
@@ -38,6 +44,7 @@ public class Configuration {
     // immutable settings
     private final String applicationName;
     private final String applicationID;
+    private final String applicationIDPercentEncoded;
     private final OpenKitType openKitType;
     private final String deviceID;
     private final String endpointURL;
@@ -71,6 +78,7 @@ public class Configuration {
         // immutable settings
         this.applicationName = applicationName;
         this.applicationID = applicationID;
+        applicationIDPercentEncoded = PercentEncoder.encode(applicationID, ENCODING_CHARSET, RESERVED_CHARACTERS);
         this.deviceID = deviceID;
         this.endpointURL = endpointURL;
 
@@ -172,6 +180,10 @@ public class Configuration {
 
     public String getApplicationID() {
         return applicationID;
+    }
+
+    public String getApplicationIDPercentEncoded() {
+        return applicationIDPercentEncoded;
     }
 
     public String getDeviceID() {

--- a/src/main/java/com/dynatrace/openkit/core/util/PercentEncoder.java
+++ b/src/main/java/com/dynatrace/openkit/core/util/PercentEncoder.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dynatrace.openkit.core.util;
+
+import java.io.UnsupportedEncodingException;
+import java.util.BitSet;
+
+/**
+ * Utility class for percent-encoding (also known as URL encoding) strings.
+ *
+ * <p>
+ *     This class works basically the same as Java's {@code URLEncoder}, except that
+ *     space characters are percent encoded and not using a plus.
+ * </p>
+ *
+ * <p>
+ *     Unlike Java's {@code URLEncoder} this class uses RFC 3986 to determine
+ *     the unreserved characters(see also <a href="https://tools.ietf.org/html/rfc3986#section-2.3">https://tools.ietf.org/html/rfc3986#section-2.3</a>)
+ * </p>
+ */
+public class PercentEncoder {
+
+    private static final int UNRESERVED_CHARACTERS_BITS = 128; // US-ASCII range
+    private static final BitSet UNRESERVED_CHARACTERS = new BitSet(UNRESERVED_CHARACTERS_BITS);
+
+    static {
+        // initialize all unreserved characters
+        for (int i = 'a'; i <= 'z'; i++) {
+            UNRESERVED_CHARACTERS.set(i);
+        }
+        for (int i = 'A'; i <= 'Z'; i++) {
+            UNRESERVED_CHARACTERS.set(i);
+        }
+        for (int i = '0'; i <= '9'; i++) {
+            UNRESERVED_CHARACTERS.set(i);
+        }
+        UNRESERVED_CHARACTERS.set('-');
+        UNRESERVED_CHARACTERS.set('.');
+        UNRESERVED_CHARACTERS.set('_');
+        UNRESERVED_CHARACTERS.set('~');
+    }
+
+    /**
+     * Default constructor.
+     *
+     * <p>
+     *     This constructor is private, since this class shall be used as utility class.
+     * </p>
+     */
+    private PercentEncoder() {
+    }
+
+    /**
+     * Percent-encode a given input string.
+     *
+     * @param input The input string to percent-encode.
+     * @param encoding Encoding used to encode characters.
+     * @return Percent encoded string.
+     */
+    public static String encode(String input, String encoding) {
+        return encode(input, encoding, null);
+    }
+
+    /**
+     * Percent-encode a given input string.
+     *
+     * @param input The input string to percent-encode.
+     * @param encoding Encoding used to encode characters.
+     * @param additionalReservedChars Characters that should be unreserved, but need
+     *                                to be considered reserved too.
+     * @return Percent encoded string.
+     */
+    public static String encode(String input, String encoding, char[] additionalReservedChars) {
+
+        BitSet unreservedSet = buildUnreservedCharacters(additionalReservedChars);
+        StringBuilder resultBuilder = new StringBuilder(input.length());
+
+        int index = 0;
+        while (index < input.length()) {
+            int c = input.charAt(index);
+            if (unreservedSet.get(c)) {
+                // unreserved character, which does need to be percent encoded
+                resultBuilder.append((char)c);
+                index++;
+            } else {
+                // reserved character, but encoding needs to be applied first
+                StringBuilder sb = new StringBuilder().append((char)c);
+                index++;
+                while (index < input.length() && !unreservedSet.get(input.charAt(index))) {
+                    sb.append(input.charAt(index));
+                    index++;
+                }
+
+                // encode temp string using given encoding; & percent encoding
+                try {
+                    byte[] encoded = sb.toString().getBytes(encoding);
+                    // now perform percent encoding
+                    for (byte b : encoded) {
+                        resultBuilder.append(hexEncode(b));
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    // should not be reached
+                    return null;
+                }
+            }
+        }
+
+        return resultBuilder.toString();
+    }
+
+    private static char[] hexEncode(byte b) {
+        char[] result = new char[3];
+        result[0] = '%';
+        char c = Character.forDigit((b >> 4) & 0x0F, 16);
+        if (Character.isLetter(c)) {
+            c = Character.toUpperCase(c);
+        }
+        result[1] = c;
+        c = Character.forDigit(b & 0x0F, 16);
+        if (Character.isLetter(c)) {
+            c = Character.toUpperCase(c);
+        }
+        result[2] = c;
+
+        return result;
+    }
+
+    private static BitSet buildUnreservedCharacters(char[] additionalReservedChars) {
+        BitSet unreservedSet = UNRESERVED_CHARACTERS;
+        if (additionalReservedChars != null && additionalReservedChars.length > 0) {
+            // duplicate the
+            unreservedSet = new BitSet(UNRESERVED_CHARACTERS_BITS);
+            unreservedSet.or(UNRESERVED_CHARACTERS);
+            for (char c : additionalReservedChars) {
+                if (c < UNRESERVED_CHARACTERS_BITS) {
+                    unreservedSet.clear(c);
+                }
+            }
+        }
+
+        return unreservedSet;
+    }
+}

--- a/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/Beacon.java
@@ -27,12 +27,12 @@ import com.dynatrace.openkit.core.configuration.BeaconConfiguration;
 import com.dynatrace.openkit.core.configuration.Configuration;
 import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
 import com.dynatrace.openkit.core.util.InetAddressValidator;
+import com.dynatrace.openkit.core.util.PercentEncoder;
 import com.dynatrace.openkit.providers.HTTPClientProvider;
 import com.dynatrace.openkit.providers.ThreadIDProvider;
 import com.dynatrace.openkit.providers.TimingProvider;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -95,6 +95,9 @@ public class Beacon {
 
     // web request tag prefix constant
     private static final String TAG_PREFIX = "MT";
+
+    // web request tag reserved characters
+    private static final char[] RESERVED_CHARACTERS = {'_'};
 
     private static final char BEACON_DATA_DELIMITER = '&';
 
@@ -276,8 +279,8 @@ public class Beacon {
         if (getBeaconConfiguration().getDataCollectionLevel() == DataCollectionLevel.OFF) {
             return "";
         }
-        return TAG_PREFIX + "_" + ProtocolConstants.PROTOCOL_VERSION + "_" + httpConfiguration.getServerID() + "_" + getDeviceID()
-            + "_" + sessionNumber + "_" + configuration.getApplicationID() + "_" + parentActionID + "_" + threadIDProvider
+        return TAG_PREFIX + "_" + ProtocolConstants.PROTOCOL_VERSION + "_" + httpConfiguration.getServerID() + "_" + PercentEncoder.encode(getDeviceID(), CHARSET, RESERVED_CHARACTERS)
+            + "_" + sessionNumber + "_" + configuration.getApplicationIDPercentEncoded() + "_" + parentActionID + "_" + threadIDProvider
             .getThreadID() + "_" + sequenceNo;
     }
 
@@ -900,12 +903,10 @@ public class Beacon {
      * @param stringValue The value to add.
      */
     private void addKeyValuePair(StringBuilder builder, String key, String stringValue) {
-        String encodedValue;
-        try {
-            encodedValue = URLEncoder.encode(stringValue, CHARSET);
-        } catch (UnsupportedEncodingException e) {
+        String encodedValue = PercentEncoder.encode(stringValue, CHARSET, RESERVED_CHARACTERS);
+        if (encodedValue == null) {
             // if encoding fails, skip this key/value pair
-            logger.error(getClass().getSimpleName() + "Skipped encoding of Key/Value: " + key + "/" + stringValue, e);
+            logger.error(getClass().getSimpleName() + "Skipped encoding of Key/Value: " + key + "/" + stringValue);
             return;
         }
 

--- a/src/main/java/com/dynatrace/openkit/protocol/HTTPClient.java
+++ b/src/main/java/com/dynatrace/openkit/protocol/HTTPClient.java
@@ -19,12 +19,12 @@ package com.dynatrace.openkit.protocol;
 import com.dynatrace.openkit.api.Logger;
 import com.dynatrace.openkit.api.SSLTrustManager;
 import com.dynatrace.openkit.core.configuration.HTTPClientConfiguration;
+import com.dynatrace.openkit.core.util.PercentEncoder;
 import com.dynatrace.openkit.protocol.ssl.SSLStrictTrustManager;
 
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -78,6 +78,9 @@ public class HTTPClient {
     private static final String QUERY_KEY_PLATFORM_TYPE = "pt";
     private static final String QUERY_KEY_AGENT_TECHNOLOGY_TYPE = "tt";
     private static final String QUERY_KEY_NEW_SESSION = "ns";
+
+    // additional reserved characters for URL encoding
+    private static final char[] QUERY_RESERVED_CHARACTERS = {'_'};
 
     // connection constants
     private static final int MAX_SEND_RETRIES = 3;
@@ -365,17 +368,10 @@ public class HTTPClient {
 
     // helper method for appending query parameters
     private static void appendQueryParam(StringBuilder urlBuilder, String key, String value) {
-        String encodedValue = "";
-        try {
-            encodedValue = URLEncoder.encode(value, Beacon.CHARSET);
-        } catch (UnsupportedEncodingException e) {
-            // must not happen, as UTF-8 should *really* be supported
-        }
-
         urlBuilder.append('&');
         urlBuilder.append(key);
         urlBuilder.append('=');
-        urlBuilder.append(encodedValue);
+        urlBuilder.append(PercentEncoder.encode(value, "UTF-8", QUERY_RESERVED_CHARACTERS));
     }
 
     // helper method for gzipping beacon data

--- a/src/test/java/com/dynatrace/openkit/core/configuration/ConfigurationTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/configuration/ConfigurationTest.java
@@ -25,6 +25,7 @@ import com.dynatrace.openkit.test.providers.TestSessionIDProvider;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
@@ -164,6 +165,24 @@ public class ConfigurationTest {
 
         //then
         assertThat(obtained, is(sameInstance(beaconConfiguration)));
+    }
+
+    @Test
+    public void getApplicationID() {
+        // given
+        TestConfiguration target = new TestConfiguration(OpenKitType.DYNATRACE, "", "/App_ID%", "777", "");
+
+        // then
+        assertThat(target.getApplicationID(), is(equalTo("/App_ID%")));
+    }
+
+    @Test
+    public void getApplicationIDPercentEncodedDoesPropperEncoding() {
+        // given
+        TestConfiguration target = new TestConfiguration(OpenKitType.DYNATRACE, "", "/App_ID%", "777", "");
+
+        // then
+        assertThat(target.getApplicationIDPercentEncoded(), is(equalTo("%2FApp%5FID%25")));
     }
 
     private final class TestConfiguration extends Configuration {

--- a/src/test/java/com/dynatrace/openkit/core/util/InetAddressValidatorTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/util/InetAddressValidatorTest.java
@@ -16,7 +16,6 @@
 
 package com.dynatrace.openkit.core.util;
 
-import com.dynatrace.openkit.core.util.InetAddressValidator;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/com/dynatrace/openkit/core/util/PercentEncoderTest.java
+++ b/src/test/java/com/dynatrace/openkit/core/util/PercentEncoderTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2018 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dynatrace.openkit.core.util;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class PercentEncoderTest {
+
+    /**
+     * All unreserved characters based on RFC-3986
+     */
+    private static final String UNRESERVED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+
+    @Test
+    public void rfc3986UnreservedCharactersAreNotEncoded() {
+        // when
+        String obtained = PercentEncoder.encode(UNRESERVED_CHARACTERS, "UTF-8");
+
+        // then
+        assertThat(obtained, is(equalTo(UNRESERVED_CHARACTERS)));
+    }
+
+    @Test
+    public void reservedCharactersArePercentEncoded() {
+        // when
+        String obtained = PercentEncoder.encode("+()/\\&%$#@!`?<>[]{}", "UTF-8");
+
+        // then
+        String expected = "%2B%28%29%2F%5C%26%25%24%23%40%21%60%3F%3C%3E%5B%5D%7B%7D"; // precomputed using Python
+        assertThat(obtained, is(equalTo(expected)));
+    }
+
+    @Test
+    public void mixingReservedAndUnreservedCharactersWorks() {
+        // when
+        String obtained = PercentEncoder.encode("a+bc()~/\\&0_", "UTF-8");
+
+        // then
+        String expected = "a%2Bbc%28%29~%2F%5C%260_"; // precomputed using Python
+        assertThat(obtained, is(equalTo(expected)));
+    }
+
+    @Test
+    public void charactersOutsideOfAsciiRangeAreEncodedFirst() {
+        // when
+        String obtained = PercentEncoder.encode("aösÖ€dÁF", "UTF-8");
+
+        // then
+        String expected = "a%C3%B6s%C3%96%E2%82%ACd%C3%81F";
+        assertThat(obtained, is(equalTo(expected)));
+    }
+
+    @Test
+    public void itIsPossibleToMarkAdditionalCharactersAsReserved() {
+        // when
+        String additionalReservedCharacters = "€0_";
+        String obtained = PercentEncoder.encode("0123456789-._~", "UTF-8", additionalReservedCharacters.toCharArray());
+
+        // then
+        String expected = "%30123456789-.%5F~";
+        assertThat(obtained, is(equalTo(expected)));
+    }
+
+    @Test
+    public void nullIsReturnedIfEncodingIsNecessaryButIsNotKnown() {
+        // when
+        String obtained = PercentEncoder.encode("a€b", "this-is-really-no-valid-encoding");
+
+        // then
+        assertThat(obtained, is(nullValue()));
+    }
+}

--- a/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
+++ b/src/test/java/com/dynatrace/openkit/protocol/BeaconTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
-@SuppressWarnings("resource")
+
 public class BeaconTest {
 
     private static final String APP_ID = "appID";
@@ -63,6 +63,7 @@ public class BeaconTest {
     public void setUp() {
         configuration = mock(Configuration.class);
         when(configuration.getApplicationID()).thenReturn(APP_ID);
+        when(configuration.getApplicationIDPercentEncoded()).thenReturn(APP_ID);
         when(configuration.getApplicationName()).thenReturn(APP_NAME);
         when(configuration.getDevice()).thenReturn(new Device("", "", ""));
         when(configuration.getDeviceID()).thenReturn(DEVICE_ID);
@@ -174,6 +175,23 @@ public class BeaconTest {
 
         // then
         assertThat(tag, is(equalTo("MT_3_" + SERVER_ID + "_" + DEVICE_ID + "_0_" + APP_ID + "_" + ACTION_ID + "_" + THREAD_ID + "_" + sequenceNo)));
+    }
+
+    @Test
+    public void createWebRequestTagEncodesDeviceIDPropperly() {
+        // given
+        when(configuration.getDeviceID()).thenReturn("device_id/");
+        final Beacon beacon = new Beacon(logger, new BeaconCacheImpl(logger), configuration, "127.0.0.1", threadIDProvider, timingProvider);
+
+        // when
+        int sequenceNo = 42;
+        String tag = beacon.createTag(ACTION_ID, sequenceNo);
+
+        // then
+        assertThat(tag, is(equalTo("MT_3_" + SERVER_ID + "_device%5Fid%2F_0_" + APP_ID + "_" + ACTION_ID + "_" + THREAD_ID + "_" + sequenceNo)));
+
+        // also ensure that the application ID is the encoded one
+        verify(configuration, times(1)).getApplicationIDPercentEncoded();
     }
 
     @Test


### PR DESCRIPTION
In addition, sometimes the underscore character _
is reserved in Dynatrace/AppMon, therefore we
need to URL-encode this character as well.

This PR is cherry-picked from https://github.com/Dynatrace/openkit-java/pull/141