### PR TITLE
Set source encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ def target = System.getenv("TARGET_COMPATIBILITY") ?: "6"
 sourceCompatibility = 1.6
 targetCompatibility = "1." + target
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
If not specified gradlew build does not execute properly in
Windows cmd.exe.