### PR TITLE
Set source encoding to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ def jvmsToTest = System.getenv("JVMS_TO_TEST") ?: "JAVA_HOME"
 sourceCompatibility = "1." + sourceTarget
 targetCompatibility = "1." + sourceTarget
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 dependencies {
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
     testCompile group: 'junit', name: 'junit', version: '4.12'


### PR DESCRIPTION
If not specified gradlew build does not execute properly in
Windows cmd.exe.