### PR TITLE
Pump version number to 1.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.dynatrace.openkit'
-version '1.0.2'
+version '1.0.3'
 
 apply plugin: 'java'
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -54,8 +54,8 @@ customize OpenKit. This includes device specific information like operating syst
 
 | Method Name | Description | Default Value |
 | ------------- | ------------- | ---------- |
-| `withApplicationVersion`  | sets the application version  | `"1.0.2"` |
-| `withOperatingSystem`  | sets the operating system name | `"OpenKit 1.0.2"` |
+| `withApplicationVersion`  | sets the application version  | `"1.0.3"` |
+| `withOperatingSystem`  | sets the operating system name | `"OpenKit 1.0.3"` |
 | `withManufacturer`  | sets the manufacturer | `"Dynatrace"` |
 | `withModelID`  | sets the model id  | `"OpenKitDevice"` |
 | `withBeaconCacheMaxRecordAge`  | sets the maximum age of an entry in the beacon cache in milliseconds | 1 h 45 min |

--- a/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
+++ b/src/main/java/com/dynatrace/openkit/api/OpenKitConstants.java
@@ -34,7 +34,7 @@ public class OpenKitConstants {
     public static final String WEBREQUEST_TAG_HEADER = "X-dynaTrace";
 
     // default values used in configuration
-    public static final String DEFAULT_APPLICATION_VERSION = "1.0.2";
+    public static final String DEFAULT_APPLICATION_VERSION = "1.0.3";
     public static final String DEFAULT_OPERATING_SYSTEM = "OpenKit " + DEFAULT_APPLICATION_VERSION;
     public static final String DEFAULT_MANUFACTURER = "Dynatrace";
     public static final String DEFAULT_MODEL_ID = "OpenKitDevice";


### PR DESCRIPTION
This is required to prepare the next release of OpenKit Java.