### PR TITLE
Backport version.properties parsing from master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ test {
 def readVersion() {
     if(version == 'unspecified') {
         Properties properties = new Properties()
-        File propertiesFile = new File('version.properties')
+        File propertiesFile = file('version.properties')
         propertiesFile.withInputStream {
             properties.load(it)
         }


### PR DESCRIPTION
As it was found out, importing OpenKit Java on a Mac
did not work as expected.
This commit backports the fix to release/1.4 branch.