### PR TITLE
Removed withApplicationName as it is deprecated

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -71,7 +71,6 @@ long deviceID = 42;
 String endpointURL = "https://tenantid.beaconurl.com/mbeacon";
 
 OpenKit openKit = new DynatraceOpenKitBuilder(endpointURL, applicationID, deviceID)
-    .withApplicationName(applicationName)
     .withApplicationVersion("1.0.0.0")
     .withOperatingSystem("Windows 10")
     .withManufacturer("MyCompany")


### PR DESCRIPTION
withApplicationName is deprecated with version 2.0, the application name is now configured in Dynatrace.